### PR TITLE
feat(users): add domain-level user entity with lifecycle states

### DIFF
--- a/src/users/entities/user.entity.spec.ts
+++ b/src/users/entities/user.entity.spec.ts
@@ -1,0 +1,169 @@
+import { User, UserStatus, UserValidationError } from './user.entity';
+
+const baseProps = () => ({
+  id: 'usr_01HABC',
+  authId: 'auth0|abc123',
+  authProvider: 'auth0',
+});
+
+describe('User entity', () => {
+  describe('create', () => {
+    it('instantiates with required fields and sensible defaults', () => {
+      const user = User.create(baseProps());
+
+      expect(user.id).toBe('usr_01HABC');
+      expect(user.authId).toBe('auth0|abc123');
+      expect(user.authProvider).toBe('auth0');
+      expect(user.status).toBe(UserStatus.PROVISIONING);
+      expect(user.email).toBeNull();
+      expect(user.displayName).toBeNull();
+      expect(user.lastLoginAt).toBeNull();
+      expect(user.createdAt).toBeInstanceOf(Date);
+      expect(user.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it('preserves provided optional fields', () => {
+      const createdAt = new Date('2026-01-01T00:00:00Z');
+      const updatedAt = new Date('2026-01-02T00:00:00Z');
+      const lastLoginAt = new Date('2026-01-03T00:00:00Z');
+      const user = User.create({
+        ...baseProps(),
+        status: UserStatus.ACTIVE,
+        email: 'a@b.co',
+        displayName: 'Dave',
+        lastLoginAt,
+        createdAt,
+        updatedAt,
+      });
+
+      expect(user.status).toBe(UserStatus.ACTIVE);
+      expect(user.email).toBe('a@b.co');
+      expect(user.displayName).toBe('Dave');
+      expect(user.lastLoginAt).toBe(lastLoginAt);
+      expect(user.createdAt).toBe(createdAt);
+      expect(user.updatedAt).toBe(updatedAt);
+    });
+  });
+
+  describe('validation', () => {
+    it.each([
+      ['empty id', { ...baseProps(), id: '' }, 'id'],
+      ['id with spaces', { ...baseProps(), id: 'bad id' }, 'id'],
+      ['empty authId', { ...baseProps(), authId: '' }, 'authId'],
+      [
+        'oversized authId',
+        { ...baseProps(), authId: 'x'.repeat(257) },
+        'authId',
+      ],
+      ['empty authProvider', { ...baseProps(), authProvider: '' }, 'authProvider'],
+      [
+        'bad status',
+        { ...baseProps(), status: 'NOT_A_STATUS' as UserStatus },
+        'status',
+      ],
+      ['bad email', { ...baseProps(), email: 'not-an-email' }, 'email'],
+      ['empty email', { ...baseProps(), email: '' }, 'email'],
+      ['empty displayName', { ...baseProps(), displayName: '' }, 'displayName'],
+    ])('rejects %s', (_name, props, field) => {
+      expect.assertions(2);
+      try {
+        User.create(props as never);
+      } catch (err) {
+        expect(err).toBeInstanceOf(UserValidationError);
+        expect((err as UserValidationError).field).toBe(field);
+      }
+    });
+
+    it('rejects updatedAt earlier than createdAt', () => {
+      expect(() =>
+        User.create({
+          ...baseProps(),
+          createdAt: new Date('2026-01-02T00:00:00Z'),
+          updatedAt: new Date('2026-01-01T00:00:00Z'),
+        }),
+      ).toThrow(UserValidationError);
+    });
+
+    it('accepts null email and null displayName', () => {
+      expect(() =>
+        User.create({ ...baseProps(), email: null, displayName: null }),
+      ).not.toThrow();
+    });
+  });
+
+  describe('state transitions', () => {
+    it('PROVISIONING -> ACTIVE allowed', () => {
+      const u = User.create(baseProps());
+      expect(u.canTransitionTo(UserStatus.ACTIVE)).toBe(true);
+      u.transitionTo(UserStatus.ACTIVE);
+      expect(u.status).toBe(UserStatus.ACTIVE);
+    });
+
+    it('ACTIVE -> RECOVERY_PENDING -> ACTIVE allowed', () => {
+      const u = User.create({ ...baseProps(), status: UserStatus.ACTIVE });
+      u.transitionTo(UserStatus.RECOVERY_PENDING);
+      expect(u.status).toBe(UserStatus.RECOVERY_PENDING);
+      u.transitionTo(UserStatus.ACTIVE);
+      expect(u.status).toBe(UserStatus.ACTIVE);
+    });
+
+    it('ACTIVE -> SUSPENDED -> ACTIVE allowed', () => {
+      const u = User.create({ ...baseProps(), status: UserStatus.ACTIVE });
+      u.transitionTo(UserStatus.SUSPENDED);
+      u.transitionTo(UserStatus.ACTIVE);
+      expect(u.status).toBe(UserStatus.ACTIVE);
+    });
+
+    it('DISABLED is terminal', () => {
+      const u = User.create({ ...baseProps(), status: UserStatus.ACTIVE });
+      u.transitionTo(UserStatus.DISABLED);
+      expect(u.canTransitionTo(UserStatus.ACTIVE)).toBe(false);
+      expect(() => u.transitionTo(UserStatus.ACTIVE)).toThrow(
+        UserValidationError,
+      );
+    });
+
+    it('PROVISIONING -> SUSPENDED is illegal', () => {
+      const u = User.create(baseProps());
+      expect(u.canTransitionTo(UserStatus.SUSPENDED)).toBe(false);
+      expect(() => u.transitionTo(UserStatus.SUSPENDED)).toThrow(
+        UserValidationError,
+      );
+    });
+
+    it('updates updatedAt on successful transition', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+      const u = User.create(baseProps());
+      const before = u.updatedAt.getTime();
+      jest.setSystemTime(new Date('2026-01-05T00:00:00Z'));
+      u.transitionTo(UserStatus.ACTIVE);
+      expect(u.updatedAt.getTime()).toBeGreaterThan(before);
+      jest.useRealTimers();
+    });
+  });
+
+  describe('predicates and helpers', () => {
+    it('isActive reflects status', () => {
+      const u = User.create({ ...baseProps(), status: UserStatus.ACTIVE });
+      expect(u.isActive()).toBe(true);
+      u.transitionTo(UserStatus.SUSPENDED);
+      expect(u.isActive()).toBe(false);
+    });
+
+    it('recordLogin updates lastLoginAt and updatedAt', () => {
+      const u = User.create({ ...baseProps(), status: UserStatus.ACTIVE });
+      const t = new Date('2026-03-01T12:00:00Z');
+      u.recordLogin(t);
+      expect(u.lastLoginAt).toBe(t);
+      expect(u.updatedAt).toBe(t);
+    });
+
+    it('recordLogin rejects non-Date input', () => {
+      const u = User.create(baseProps());
+      expect(() => u.recordLogin('now' as unknown as Date)).toThrow(
+        UserValidationError,
+      );
+    });
+  });
+});

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,1 +1,252 @@
-export class User {}
+/**
+ * Internal lifecycle states for a domain user.
+ *
+ * Kept independent of any auth provider's notion of "user state". These
+ * states drive recovery, suspension, and access-control logic across the
+ * platform.
+ */
+export enum UserStatus {
+  /** Created but not yet usable (e.g. awaiting first wallet provisioning). */
+  PROVISIONING = 'PROVISIONING',
+  /** Fully operational; the default for healthy accounts. */
+  ACTIVE = 'ACTIVE',
+  /** Account is undergoing recovery (e.g. lost device, wallet rotation). */
+  RECOVERY_PENDING = 'RECOVERY_PENDING',
+  /** Operationally paused (e.g. risk hold). Reversible. */
+  SUSPENDED = 'SUSPENDED',
+  /** Permanently disabled. No further use. */
+  DISABLED = 'DISABLED',
+}
+
+/**
+ * Allowed state transitions. Anything not listed is rejected.
+ * DISABLED is terminal.
+ */
+const ALLOWED_TRANSITIONS: Readonly<Record<UserStatus, readonly UserStatus[]>> =
+  {
+    [UserStatus.PROVISIONING]: [UserStatus.ACTIVE, UserStatus.DISABLED],
+    [UserStatus.ACTIVE]: [
+      UserStatus.RECOVERY_PENDING,
+      UserStatus.SUSPENDED,
+      UserStatus.DISABLED,
+    ],
+    [UserStatus.RECOVERY_PENDING]: [
+      UserStatus.ACTIVE,
+      UserStatus.SUSPENDED,
+      UserStatus.DISABLED,
+    ],
+    [UserStatus.SUSPENDED]: [UserStatus.ACTIVE, UserStatus.DISABLED],
+    [UserStatus.DISABLED]: [],
+  };
+
+export interface UserProps {
+  id: string;
+  authId: string;
+  authProvider: string;
+  status?: UserStatus;
+  email?: string | null;
+  displayName?: string | null;
+  lastLoginAt?: Date | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export class UserValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly field?: string,
+  ) {
+    super(message);
+    this.name = 'UserValidationError';
+  }
+}
+
+const ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_AUTH_ID_LENGTH = 256;
+const MAX_DISPLAY_NAME_LENGTH = 128;
+const MAX_EMAIL_LENGTH = 320;
+const MAX_AUTH_PROVIDER_LENGTH = 64;
+
+/**
+ * Domain-level user.
+ *
+ * This is the platform's stable internal representation of a person, decoupled
+ * from any specific authentication provider (Clerk, Auth0, Firebase, etc.).
+ * Persistence shape and provider integration live elsewhere — this class only
+ * encodes invariants and lifecycle rules.
+ */
+export class User {
+  readonly id: string;
+  readonly authId: string;
+  readonly authProvider: string;
+  status: UserStatus;
+  email: string | null;
+  displayName: string | null;
+  lastLoginAt: Date | null;
+  readonly createdAt: Date;
+  updatedAt: Date;
+
+  private constructor(props: Required<UserProps>) {
+    this.id = props.id;
+    this.authId = props.authId;
+    this.authProvider = props.authProvider;
+    this.status = props.status;
+    this.email = props.email;
+    this.displayName = props.displayName;
+    this.lastLoginAt = props.lastLoginAt;
+    this.createdAt = props.createdAt;
+    this.updatedAt = props.updatedAt;
+  }
+
+  /**
+   * Build and validate a User. Throws {@link UserValidationError} on invalid
+   * input. Use this rather than `new User(...)` so invariants are always
+   * checked.
+   */
+  static create(props: UserProps): User {
+    const now = new Date();
+    const normalized: Required<UserProps> = {
+      id: props.id,
+      authId: props.authId,
+      authProvider: props.authProvider,
+      status: props.status ?? UserStatus.PROVISIONING,
+      email: props.email ?? null,
+      displayName: props.displayName ?? null,
+      lastLoginAt: props.lastLoginAt ?? null,
+      createdAt: props.createdAt ?? now,
+      updatedAt: props.updatedAt ?? now,
+    };
+
+    User.validate(normalized);
+    return new User(normalized);
+  }
+
+  /**
+   * Validate user state. Returns void on success, throws
+   * {@link UserValidationError} on failure.
+   */
+  static validate(props: Required<UserProps>): void {
+    if (
+      typeof props.id !== 'string' ||
+      props.id.length === 0 ||
+      !ID_PATTERN.test(props.id)
+    ) {
+      throw new UserValidationError('id must be a non-empty token', 'id');
+    }
+
+    if (
+      typeof props.authId !== 'string' ||
+      props.authId.length === 0 ||
+      props.authId.length > MAX_AUTH_ID_LENGTH
+    ) {
+      throw new UserValidationError(
+        `authId must be a non-empty string up to ${MAX_AUTH_ID_LENGTH} chars`,
+        'authId',
+      );
+    }
+
+    if (
+      typeof props.authProvider !== 'string' ||
+      props.authProvider.length === 0 ||
+      props.authProvider.length > MAX_AUTH_PROVIDER_LENGTH
+    ) {
+      throw new UserValidationError(
+        `authProvider must be a non-empty string up to ${MAX_AUTH_PROVIDER_LENGTH} chars`,
+        'authProvider',
+      );
+    }
+
+    if (!Object.values(UserStatus).includes(props.status)) {
+      throw new UserValidationError(
+        `status must be one of ${Object.values(UserStatus).join(', ')}`,
+        'status',
+      );
+    }
+
+    if (props.email !== null) {
+      if (
+        typeof props.email !== 'string' ||
+        props.email.length === 0 ||
+        props.email.length > MAX_EMAIL_LENGTH ||
+        !EMAIL_PATTERN.test(props.email)
+      ) {
+        throw new UserValidationError(
+          'email must be a valid address or null',
+          'email',
+        );
+      }
+    }
+
+    if (props.displayName !== null) {
+      if (
+        typeof props.displayName !== 'string' ||
+        props.displayName.length === 0 ||
+        props.displayName.length > MAX_DISPLAY_NAME_LENGTH
+      ) {
+        throw new UserValidationError(
+          `displayName must be a non-empty string up to ${MAX_DISPLAY_NAME_LENGTH} chars, or null`,
+          'displayName',
+        );
+      }
+    }
+
+    if (props.lastLoginAt !== null && !(props.lastLoginAt instanceof Date)) {
+      throw new UserValidationError(
+        'lastLoginAt must be a Date or null',
+        'lastLoginAt',
+      );
+    }
+
+    if (
+      !(props.createdAt instanceof Date) ||
+      !(props.updatedAt instanceof Date)
+    ) {
+      throw new UserValidationError(
+        'createdAt and updatedAt must be Date instances',
+        'timestamps',
+      );
+    }
+
+    if (props.updatedAt.getTime() < props.createdAt.getTime()) {
+      throw new UserValidationError(
+        'updatedAt cannot precede createdAt',
+        'timestamps',
+      );
+    }
+  }
+
+  /** Returns true iff transitioning from current status to `next` is allowed. */
+  canTransitionTo(next: UserStatus): boolean {
+    return ALLOWED_TRANSITIONS[this.status].includes(next);
+  }
+
+  /**
+   * Move the user to a new status. Throws {@link UserValidationError} if the
+   * transition is not allowed. Updates `updatedAt`.
+   */
+  transitionTo(next: UserStatus): void {
+    if (!this.canTransitionTo(next)) {
+      throw new UserValidationError(
+        `illegal transition: ${this.status} -> ${next}`,
+        'status',
+      );
+    }
+    this.status = next;
+    this.updatedAt = new Date();
+  }
+
+  /** Convenience predicate: account is currently usable for signing/custody. */
+  isActive(): boolean {
+    return this.status === UserStatus.ACTIVE;
+  }
+
+  /** Record a successful login. Updates `lastLoginAt` and `updatedAt`. */
+  recordLogin(at: Date = new Date()): void {
+    if (!(at instanceof Date)) {
+      throw new UserValidationError('login timestamp must be a Date', 'at');
+    }
+    this.lastLoginAt = at;
+    this.updatedAt = at;
+  }
+}


### PR DESCRIPTION
## Summary
- Introduces a domain-level `User` entity decoupled from any auth provider (Clerk/Auth0/Firebase).
- Defines a `UserStatus` enum with future-ready states: `PROVISIONING`, `ACTIVE`, `RECOVERY_PENDING`, `SUSPENDED`, `DISABLED`.
- Encodes allowed state transitions (e.g. `DISABLED` is terminal; `PROVISIONING -> SUSPENDED` is illegal).
- Adds field-level validation (id, authId, email, displayName, timestamps) with a typed `UserValidationError`.
- Adds helpers: `User.create(...)`, `canTransitionTo`, `transitionTo`, `isActive`, `recordLogin`.
- 22-test unit spec covering construction, validation, transitions, and helpers.

## Closes
closes #2

## Test plan
- [x] `jest --testPathPatterns=user.entity` — all 22 cases pass locally
- [x] No new runtime deps; validation implemented without `class-validator` to keep the entity provider-agnostic and stdlib-only
