### PR TITLE
feat: prisma schema alignment, CRUD modules for Developer/Project, and FK indexes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -164,6 +164,7 @@ model Wallet {
   @@unique([network, publicKey])
   @@index([userId, network])
   @@index([status, network])
+  @@index([rotatedFromId])
 }
 
 /// Recovery request lifecycle states
@@ -254,47 +255,64 @@ model Project {
 /// API Key for developer authentication
 model ApiKey {
   id              String       @id @default(uuid())
-  
+
   /// Human-readable key name/description
   name            String
-  
+
   /// Hashed API key (never store plaintext)
   keyHash         String       @unique
-  
+
   /// Key prefix for identification (e.g., "mux_live_" or "mux_test_")
   keyPrefix       String
-  
+
   /// Last 4 characters of the key for identification
   lastFour        String
-  
+
   /// Project reference
   projectId       String
   project         Project      @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  
+
   /// Key status
   status          ApiKeyStatus @default(ACTIVE)
-  
+
   /// Key expiration (optional)
   expiresAt       DateTime?
-  
+
   /// Last used timestamp
   lastUsedAt      DateTime?
-  
+
   /// Revocation info
   revokedAt       DateTime?
   revokedReason   String?
-  
+
   /// Metadata
   createdAt       DateTime     @default(now())
   updatedAt       DateTime     @updatedAt
-  
+
   /// Relations
-  usageRecords    ApiKeyUsage[]
-  
+  usageRecords     ApiKeyUsage[]
+  rateLimitRecords RateLimitRecord[]
+
   @@index([keyHash])
   @@index([projectId])
   @@index([status])
   @@index([keyPrefix])
+}
+
+/// Sliding-window rate limit tracking per API key and endpoint
+model RateLimitRecord {
+  id           String   @id @default(uuid())
+  apiKeyId     String
+  apiKey       ApiKey   @relation(fields: [apiKeyId], references: [id], onDelete: Cascade)
+  endpoint     String
+  windowStart  DateTime
+  requestCount Int      @default(0)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@unique([apiKeyId, endpoint, windowStart])
+  @@index([apiKeyId])
+  @@index([windowStart])
 }
 
 /// API Key usage tracking for analytics and rate limiting
@@ -561,6 +579,8 @@ model Transaction {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   
+  @@index([senderWalletId])
+  @@index([receiverWalletId])
   @@index([senderWalletId, status])
   @@index([receiverWalletId, status])
   @@index([status, createdAt])

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,8 @@ import { KeyManagementModule } from './key-management/key-management.module';
 import { BalanceIndexerModule } from './balance-indexer/balance-indexer.module';
 import { WebhookModule } from './webhooks/webhook.module';
 import { TransactionsModule } from './transactions/transactions.module';
+import { DevelopersModule } from './developers/developers.module';
+import { ProjectsModule } from './projects/projects.module';
 
 
 @Module({
@@ -40,6 +42,8 @@ import { TransactionsModule } from './transactions/transactions.module';
     BalanceIndexerModule,
     WebhookModule,
     TransactionsModule,
+    DevelopersModule,
+    ProjectsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/developers/developers.controller.ts
+++ b/src/developers/developers.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { DevelopersService } from './developers.service';
+import { CreateDeveloperDto } from './dto/create-developer.dto';
+import { UpdateDeveloperDto } from './dto/update-developer.dto';
+
+@Controller('developers')
+export class DevelopersController {
+  constructor(private readonly developersService: DevelopersService) {}
+
+  @Post()
+  create(@Body() dto: CreateDeveloperDto) {
+    return this.developersService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.developersService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.developersService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateDeveloperDto) {
+    return this.developersService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.developersService.remove(id);
+  }
+}

--- a/src/developers/developers.module.ts
+++ b/src/developers/developers.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { DevelopersService } from './developers.service';
+import { DevelopersController } from './developers.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [DevelopersController],
+  providers: [DevelopersService],
+  exports: [DevelopersService],
+})
+export class DevelopersModule {}

--- a/src/developers/developers.service.ts
+++ b/src/developers/developers.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateDeveloperDto } from './dto/create-developer.dto';
+import { UpdateDeveloperDto } from './dto/update-developer.dto';
+
+@Injectable()
+export class DevelopersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  create(dto: CreateDeveloperDto) {
+    return this.prisma.developer.create({ data: dto });
+  }
+
+  findAll() {
+    return this.prisma.developer.findMany();
+  }
+
+  async findOne(id: string) {
+    const developer = await this.prisma.developer.findUnique({ where: { id } });
+    if (!developer) throw new NotFoundException(`Developer ${id} not found`);
+    return developer;
+  }
+
+  async update(id: string, dto: UpdateDeveloperDto) {
+    await this.findOne(id);
+    return this.prisma.developer.update({ where: { id }, data: dto });
+  }
+
+  async remove(id: string) {
+    await this.findOne(id);
+    return this.prisma.developer.delete({ where: { id } });
+  }
+}

--- a/src/developers/dto/create-developer.dto.ts
+++ b/src/developers/dto/create-developer.dto.ts
@@ -1,0 +1,14 @@
+import { IsEmail, IsOptional, IsString } from 'class-validator';
+
+export class CreateDeveloperDto {
+  @IsEmail()
+  email: string;
+
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  company?: string;
+}

--- a/src/developers/dto/update-developer.dto.ts
+++ b/src/developers/dto/update-developer.dto.ts
@@ -1,0 +1,9 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { IsOptional, IsString } from 'class-validator';
+import { CreateDeveloperDto } from './create-developer.dto';
+
+export class UpdateDeveloperDto extends PartialType(CreateDeveloperDto) {
+  @IsOptional()
+  @IsString()
+  status?: string;
+}

--- a/src/projects/dto/create-project.dto.ts
+++ b/src/projects/dto/create-project.dto.ts
@@ -1,0 +1,22 @@
+import { IsInt, IsOptional, IsString, Min } from 'class-validator';
+
+export class CreateProjectDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  developerId: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  environment?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  rateLimitRpm?: number;
+}

--- a/src/projects/dto/update-project.dto.ts
+++ b/src/projects/dto/update-project.dto.ts
@@ -1,0 +1,9 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { IsOptional, IsString } from 'class-validator';
+import { CreateProjectDto } from './create-project.dto';
+
+export class UpdateProjectDto extends PartialType(CreateProjectDto) {
+  @IsOptional()
+  @IsString()
+  status?: string;
+}

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -1,0 +1,44 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Query,
+} from '@nestjs/common';
+import { ProjectsService } from './projects.service';
+import { CreateProjectDto } from './dto/create-project.dto';
+import { UpdateProjectDto } from './dto/update-project.dto';
+
+@Controller('projects')
+export class ProjectsController {
+  constructor(private readonly projectsService: ProjectsService) {}
+
+  @Post()
+  create(@Body() dto: CreateProjectDto) {
+    return this.projectsService.create(dto);
+  }
+
+  @Get()
+  findAll(@Query('developerId') developerId?: string) {
+    if (developerId) return this.projectsService.findByDeveloper(developerId);
+    return this.projectsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.projectsService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateProjectDto) {
+    return this.projectsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.projectsService.remove(id);
+  }
+}

--- a/src/projects/projects.module.ts
+++ b/src/projects/projects.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ProjectsService } from './projects.service';
+import { ProjectsController } from './projects.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ProjectsController],
+  providers: [ProjectsService],
+  exports: [ProjectsService],
+})
+export class ProjectsModule {}

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateProjectDto } from './dto/create-project.dto';
+import { UpdateProjectDto } from './dto/update-project.dto';
+
+@Injectable()
+export class ProjectsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  create(dto: CreateProjectDto) {
+    return this.prisma.project.create({ data: dto });
+  }
+
+  findAll() {
+    return this.prisma.project.findMany();
+  }
+
+  findByDeveloper(developerId: string) {
+    return this.prisma.project.findMany({ where: { developerId } });
+  }
+
+  async findOne(id: string) {
+    const project = await this.prisma.project.findUnique({ where: { id } });
+    if (!project) throw new NotFoundException(`Project ${id} not found`);
+    return project;
+  }
+
+  async update(id: string, dto: UpdateProjectDto) {
+    await this.findOne(id);
+    return this.prisma.project.update({ where: { id }, data: dto });
+  }
+
+  async remove(id: string) {
+    await this.findOne(id);
+    return this.prisma.project.delete({ where: { id } });
+  }
+}


### PR DESCRIPTION
## Summary

- **#126** — Added `RateLimitRecord` Prisma model with `apiKeyId`, `endpoint`, `windowStart`, `requestCount` fields and a compound unique index; added relation on `ApiKey`. This aligns the schema with the existing `rate-limit.service.ts` which already references `prisma.rateLimitRecord`.
- **#127** — Created `DevelopersModule` with full CRUD: `DevelopersService` (Prisma-backed), `DevelopersController` (`POST /developers`, `GET /developers`, `GET /developers/:id`, `PATCH /developers/:id`, `DELETE /developers/:id`), and DTOs.
- **#128** — Created `ProjectsModule` with full CRUD: `ProjectsService` (Prisma-backed, supports `findByDeveloper`), `ProjectsController` (supports `?developerId` query filter), and DTOs.
- **#129** — Added `@@index([rotatedFromId])` on `Wallet` (missing FK index on self-referential relation) and standalone `@@index([senderWalletId])` / `@@index([receiverWalletId])` on `Transaction` to support efficient FK lookups alongside the existing composite indexes.

## Closes

Closes #126
Closes #127
Closes #128
Closes #129

## Test plan

- [ ] Run `prisma validate` to confirm schema is valid
- [ ] Run `prisma migrate dev` against a dev database to verify all model and index changes apply cleanly
- [ ] `POST /developers` creates a developer record
- [ ] `GET /developers/:id` returns 404 for unknown id
- [ ] `PATCH /developers/:id` updates fields correctly
- [ ] `DELETE /developers/:id` removes the record
- [ ] `POST /projects` creates a project linked to a developer
- [ ] `GET /projects?developerId=x` filters by developer
- [ ] Rate limiter uses `RateLimitRecord` via Prisma without errors