### PR TITLE
feat(payments): implement update endpoint with status transition vali…

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "pg": "^8.17.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "stellar-sdk": "^10.2.0",
-
+    "stellar-sdk": "^10.2.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/payments/dto/update-payment.dto.ts
+++ b/src/payments/dto/update-payment.dto.ts
@@ -1,4 +1,12 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreatePaymentDto } from './create-payment.dto';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { PaymentStatus } from '../entities/payment.entity';
 
-export class UpdatePaymentDto extends PartialType(CreatePaymentDto) {}
+export class UpdatePaymentDto {
+  @IsOptional()
+  @IsEnum(PaymentStatus)
+  status?: PaymentStatus;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+}

--- a/src/payments/payments.controller.spec.ts
+++ b/src/payments/payments.controller.spec.ts
@@ -1,31 +1,70 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { PaymentsController } from './payments.controller';
 import { PaymentsService } from './payments.service';
+import { ApiKeyGuard } from '../api-keys/api-key.guard';
+import { RateLimitGuard } from '../rate-limit/rate-limit.guard';
+import { PaymentStatus } from './entities/payment.entity';
 
 describe('PaymentsController', () => {
   let controller: PaymentsController;
+  let paymentsService: { update: jest.Mock } & Record<string, jest.Mock>;
 
   beforeEach(async () => {
+    paymentsService = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [PaymentsController],
-      providers: [
-        {
-          provide: PaymentsService,
-          useValue: {
-            create: jest.fn(),
-            findAll: jest.fn(),
-            findOne: jest.fn(),
-            update: jest.fn(),
-            remove: jest.fn(),
-          },
-        },
-      ],
-    }).compile();
+      providers: [{ provide: PaymentsService, useValue: paymentsService }],
+    })
+      .overrideGuard(ApiKeyGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RateLimitGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     controller = module.get<PaymentsController>(PaymentsController);
   });
 
+  afterEach(() => jest.clearAllMocks());
+
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('update', () => {
+    it('should delegate to service and return updated payment', async () => {
+      const updated = { id: 1, status: PaymentStatus.CONFIRMED };
+      paymentsService.update.mockResolvedValue(updated);
+
+      const result = await controller.update('1', { status: PaymentStatus.CONFIRMED });
+
+      expect(paymentsService.update).toHaveBeenCalledWith(1, { status: PaymentStatus.CONFIRMED });
+      expect(result).toEqual(updated);
+    });
+
+    it('should propagate NotFoundException from service', async () => {
+      paymentsService.update.mockRejectedValue(new NotFoundException('Payment #99 not found'));
+
+      await expect(
+        controller.update('99', { status: PaymentStatus.CONFIRMED }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should propagate BadRequestException from service', async () => {
+      paymentsService.update.mockRejectedValue(
+        new BadRequestException('Cannot transition payment from CONFIRMED to FAILED'),
+      );
+
+      await expect(
+        controller.update('1', { status: PaymentStatus.FAILED }),
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 });

--- a/src/payments/payments.service.spec.ts
+++ b/src/payments/payments.service.spec.ts
@@ -1,7 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { PaymentsService } from './payments.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { LimitsService } from '../limits/limits.service';
+import { PaymentStatus } from './entities/payment.entity';
 
 describe('PaymentsService', () => {
   let service: PaymentsService;
@@ -14,6 +16,7 @@ describe('PaymentsService', () => {
         create: jest.fn(),
         findMany: jest.fn(),
         findUnique: jest.fn(),
+        update: jest.fn(),
       },
     };
     limitsService = {
@@ -95,6 +98,96 @@ describe('PaymentsService', () => {
         'Limit exceeded',
       );
       expect(prisma.payment.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update', () => {
+    const pendingPayment = {
+      id: 1,
+      status: PaymentStatus.PENDING,
+      amount: 100,
+      currency: 'USD',
+    };
+
+    it('should update status from PENDING to CONFIRMED', async () => {
+      prisma.payment.findUnique.mockResolvedValue(pendingPayment);
+      const updated = { ...pendingPayment, status: PaymentStatus.CONFIRMED };
+      prisma.payment.update.mockResolvedValue(updated);
+
+      const result = await service.update(1, { status: PaymentStatus.CONFIRMED });
+
+      expect(prisma.payment.findUnique).toHaveBeenCalledWith({ where: { id: 1 } });
+      expect(prisma.payment.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { status: PaymentStatus.CONFIRMED },
+      });
+      expect(result.status).toBe(PaymentStatus.CONFIRMED);
+    });
+
+    it('should update status from PENDING to FAILED', async () => {
+      prisma.payment.findUnique.mockResolvedValue(pendingPayment);
+      const updated = { ...pendingPayment, status: PaymentStatus.FAILED };
+      prisma.payment.update.mockResolvedValue(updated);
+
+      const result = await service.update(1, { status: PaymentStatus.FAILED });
+
+      expect(result.status).toBe(PaymentStatus.FAILED);
+    });
+
+    it('should update description without status change', async () => {
+      prisma.payment.findUnique.mockResolvedValue(pendingPayment);
+      const updated = { ...pendingPayment, description: 'new desc' };
+      prisma.payment.update.mockResolvedValue(updated);
+
+      const result = await service.update(1, { description: 'new desc' });
+
+      expect(prisma.payment.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { description: 'new desc' },
+      });
+      expect(result.description).toBe('new desc');
+    });
+
+    it('should throw NotFoundException when payment does not exist', async () => {
+      prisma.payment.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.update(99, { status: PaymentStatus.CONFIRMED }),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.payment.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when transitioning from CONFIRMED', async () => {
+      prisma.payment.findUnique.mockResolvedValue({
+        ...pendingPayment,
+        status: PaymentStatus.CONFIRMED,
+      });
+
+      await expect(
+        service.update(1, { status: PaymentStatus.FAILED }),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.payment.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when transitioning from FAILED', async () => {
+      prisma.payment.findUnique.mockResolvedValue({
+        ...pendingPayment,
+        status: PaymentStatus.FAILED,
+      });
+
+      await expect(
+        service.update(1, { status: PaymentStatus.CONFIRMED }),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.payment.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when transitioning PENDING to PENDING', async () => {
+      prisma.payment.findUnique.mockResolvedValue(pendingPayment);
+
+      await expect(
+        service.update(1, { status: PaymentStatus.PENDING }),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.payment.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/payments/payments.service.ts
+++ b/src/payments/payments.service.ts
@@ -1,8 +1,20 @@
-import { Injectable } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
 import { CreatePaymentDto } from './dto/create-payment.dto';
 import { UpdatePaymentDto } from './dto/update-payment.dto';
 import { PrismaService } from '../prisma/prisma.service';
 import { LimitsService } from '../limits/limits.service';
+import { PaymentStatus } from './entities/payment.entity';
+
+// Only PENDING payments can be transitioned; terminal states are immutable.
+const ALLOWED_TRANSITIONS: Record<string, PaymentStatus[]> = {
+  [PaymentStatus.PENDING]: [PaymentStatus.CONFIRMED, PaymentStatus.FAILED],
+  [PaymentStatus.CONFIRMED]: [],
+  [PaymentStatus.FAILED]: [],
+};
 
 @Injectable()
 export class PaymentsService {
@@ -37,8 +49,25 @@ export class PaymentsService {
     return this.prisma.payment.findUnique({ where: { id } });
   }
 
-  update(id: number, updatePaymentDto: UpdatePaymentDto) {
-    return `This action updates a #${id} payment`;
+  async update(id: number, updatePaymentDto: UpdatePaymentDto) {
+    const payment = await this.prisma.payment.findUnique({ where: { id } });
+    if (!payment) {
+      throw new NotFoundException(`Payment #${id} not found`);
+    }
+
+    if (updatePaymentDto.status !== undefined) {
+      const allowed = ALLOWED_TRANSITIONS[payment.status] ?? [];
+      if (!allowed.includes(updatePaymentDto.status)) {
+        throw new BadRequestException(
+          `Cannot transition payment from ${payment.status} to ${updatePaymentDto.status}`,
+        );
+      }
+    }
+
+    return this.prisma.payment.update({
+      where: { id },
+      data: updatePaymentDto,
+    });
   }
 
   remove(id: number) {


### PR DESCRIPTION
feat(payments): implement update endpoint with status transition validation
  
  Implements the PATCH /payments/:id endpoint, which was previously a stub returning a plain
  string.
  
  Changes
  
  - PaymentsService.update() — looks up the payment by ID, validates the status transition, and
  persists the update via Prisma
  - UpdatePaymentDto — replaced PartialType(CreatePaymentDto) with explicit status (enum) and
  description (string) fields; the global ValidationPipe rejects any other fields
  - Fixed a pre-existing trailing comma in package.json that prevented Jest from running
  
  Status transition rules
  
  - PENDING → CONFIRMED ✅
  - PENDING → FAILED ✅
  - Any transition from CONFIRMED or FAILED → 400 Bad Request
  - Unknown payment ID → 404 Not Found
  
  Tests
  
  - 7 service unit tests: happy paths, NotFoundException, and all invalid transition cases
  - 3 controller unit tests: delegation, NotFoundException propagation, BadRequestException
   propagation
  - No regressions in existing payments tests
  - closes #221
