### PR TITLE
Feat/wallet orchestrator failure rollback

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      stellar-sdk:
+        specifier: ^10.2.0
+        version: 10.4.1
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.2.0
@@ -999,6 +1002,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/eventsource@1.1.15':
+    resolution: {integrity: sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==}
+
   '@types/express-serve-static-core@5.1.1':
     resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
 
@@ -1035,6 +1041,9 @@ packages:
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
 
+  '@types/randombytes@2.0.3':
+    resolution: {integrity: sha512-+NRgihTfuURllWCiIAhm1wsJqzsocnqXM77V/CalsdJIYSRGEHMnritxh+6EsBklshC+clo1KgnN14qgSGeQdw==}
+
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
@@ -1055,6 +1064,9 @@ packages:
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
+
+  '@types/urijs@1.19.26':
+    resolution: {integrity: sha512-wkXrVzX5yoqLnndOwFsieJA7oKM8cNkOKJtf/3vVGSUFkWDKZvFHpIl9Pvqb/T9UsawBBFMTTD8xu7sK5MWuvg==}
 
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
@@ -1401,9 +1413,16 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
+
+  axios@0.25.0:
+    resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
 
   axios@1.16.1:
     resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
@@ -1436,12 +1455,19 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base32.js@0.1.0:
+    resolution: {integrity: sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==}
+    engines: {node: '>=0.12.0'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   baseline-browser-mapping@2.9.15:
     resolution: {integrity: sha512-kX8h7K2srmDyYnXRIppo4AH/wYgzWVCs+eKr3RusRSQ5PvRYoEFmR/I0PbdTjKFAoKqp5+kbxnNTFO9jOfSVJg==}
     hasBin: true
+
+  bignumber.js@4.1.0:
+    resolution: {integrity: sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -1500,6 +1526,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
     engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
@@ -1678,6 +1708,9 @@ packages:
       typescript:
         optional: true
 
+  crc@3.8.0:
+    resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
+
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
@@ -1719,6 +1752,10 @@ packages:
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
@@ -1740,6 +1777,9 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
@@ -1823,6 +1863,9 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  es6-promise@4.2.8:
+    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1922,6 +1965,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource@1.1.2:
+    resolution: {integrity: sha512-xAH3zWhgO2/3KIniEKYPr8plNSzlGINOUqYj0m0u7AB81iRw8b/3E73W6AuU+6klLbaSFmZnaETQ2lXPfAydrA==}
+    engines: {node: '>=0.12.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -2014,6 +2061,10 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -2143,6 +2194,9 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -2219,6 +2273,10 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2253,9 +2311,16 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2426,6 +2491,10 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-xdr@1.3.0:
+    resolution: {integrity: sha512-fjLTm2uBtFvWsE3l2J14VjTuuB8vJfeTtYuNS7LiLHDWIX2kt0l1pqq9334F8kODUkKPMuULjEcbGbkFFwhx5g==}
+    deprecated: ⚠️ This package has moved to @stellar/js-xdr! 🚚
+
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
@@ -2514,6 +2583,10 @@ packages:
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
+
+  long@2.4.0:
+    resolution: {integrity: sha512-ijUtjmO/n2A5PaosNG9ZGDsQ3vxJg7ZW8vsY8Kp0f2yIZWhSJvjmegV7t+9RPQKxKrvj8yKGehhS+po14hPLGQ==}
+    engines: {node: '>=0.6'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -2665,6 +2738,10 @@ packages:
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -2846,6 +2923,10 @@ packages:
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
 
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
@@ -3047,8 +3128,17 @@ packages:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
 
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3084,6 +3174,9 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  sodium-native@3.4.1:
+    resolution: {integrity: sha512-PaNN/roiFWzVVTL6OqjzYct38NSXewdl2wz8SRB51Br/MLIJPrbM3XexhVWkq7D3UWMysfrhKVf1v1phZq6MeQ==}
 
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
@@ -3124,6 +3217,14 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  stellar-base@8.2.2:
+    resolution: {integrity: sha512-YVCIuJXU1bPn+vU0ded+g0D99DcpYXH9CEXfpYEDc4Gf04h65YjOVhGojQBm1hqVHq3rKT7m1tgfNACkU84FTA==}
+    deprecated: ⚠️ This package has moved to @stellar/stellar-base! 🚚
+
+  stellar-sdk@10.4.1:
+    resolution: {integrity: sha512-Wdm2UoLuN9SNrSEHO0R/I+iZuRwUkfny1xg4akhGCpO8LQZw8QzuMTJvbEoMT3sHT4/eWYiteVLp7ND21xZf5A==}
+    deprecated: ⚠️ This package has moved to @stellar/stellar-sdk! 🚚
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -3236,6 +3337,10 @@ packages:
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
+  to-buffer@1.2.2:
+    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
+    engines: {node: '>= 0.4'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -3247,6 +3352,9 @@ packages:
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
+
+  toml@2.3.6:
+    resolution: {integrity: sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==}
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -3310,8 +3418,14 @@ packages:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -3340,6 +3454,10 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
@@ -3392,8 +3510,15 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  urijs@1.19.11:
+    resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utility-types@3.11.0:
+    resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
+    engines: {node: '>= 4'}
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -3445,6 +3570,10 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  which-typed-array@1.1.21:
+    resolution: {integrity: sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==}
+    engines: {node: '>= 0.4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4557,6 +4686,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/eventsource@1.1.15': {}
+
   '@types/express-serve-static-core@5.1.1':
     dependencies:
       '@types/node': 22.19.7
@@ -4603,6 +4734,10 @@ snapshots:
 
   '@types/qs@6.14.0': {}
 
+  '@types/randombytes@2.0.3':
+    dependencies:
+      '@types/node': 22.19.7
+
   '@types/range-parser@1.2.7': {}
 
   '@types/react@19.2.9':
@@ -4631,6 +4766,8 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
+
+  '@types/urijs@1.19.26': {}
 
   '@types/validator@13.15.10': {}
 
@@ -4973,7 +5110,17 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
   aws-ssl-profiles@1.1.2: {}
+
+  axios@0.25.0:
+    dependencies:
+      follow-redirects: 1.16.0
+    transitivePeerDependencies:
+      - debug
 
   axios@1.16.1:
     dependencies:
@@ -5039,9 +5186,13 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base32.js@0.1.0: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.15: {}
+
+  bignumber.js@4.1.0: {}
 
   bl@4.1.0:
     dependencies:
@@ -5135,6 +5286,13 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
 
   call-bound@1.0.4:
     dependencies:
@@ -5284,6 +5442,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  crc@3.8.0:
+    dependencies:
+      buffer: 5.7.1
+
   create-require@1.1.1: {}
 
   cross-spawn@7.0.6:
@@ -5310,6 +5472,12 @@ snapshots:
     dependencies:
       clone: 1.0.4
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   defu@6.1.4: {}
 
   delayed-stream@1.0.0: {}
@@ -5321,6 +5489,8 @@ snapshots:
   destr@2.0.5: {}
 
   detect-newline@3.1.0: {}
+
+  detect-node@2.1.0: {}
 
   dezalgo@1.0.4:
     dependencies:
@@ -5391,6 +5561,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es6-promise@4.2.8: {}
 
   escalade@3.2.0: {}
 
@@ -5494,6 +5666,8 @@ snapshots:
   etag@1.8.1: {}
 
   events@3.3.0: {}
+
+  eventsource@1.1.2: {}
 
   execa@5.1.1:
     dependencies:
@@ -5623,6 +5797,10 @@ snapshots:
   flatted@3.3.3: {}
 
   follow-redirects@1.16.0: {}
+
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
 
   foreground-child@3.3.1:
     dependencies:
@@ -5773,6 +5951,10 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
@@ -5839,6 +6021,8 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
+  is-callable@1.2.7: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -5859,7 +6043,13 @@ snapshots:
 
   is-stream@2.0.1: {}
 
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.21
+
   is-unicode-supported@0.1.0: {}
+
+  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
@@ -6224,6 +6414,11 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-xdr@1.3.0:
+    dependencies:
+      lodash: 4.17.21
+      long: 2.4.0
+
   js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
@@ -6294,6 +6489,8 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+
+  long@2.4.0: {}
 
   long@5.3.2: {}
 
@@ -6423,6 +6620,9 @@ snapshots:
       lodash: 4.17.21
 
   node-fetch-native@1.6.7: {}
+
+  node-gyp-build@4.8.4:
+    optional: true
 
   node-int64@0.4.0: {}
 
@@ -6592,6 +6792,8 @@ snapshots:
       pathe: 2.0.3
 
   pluralize@8.0.0: {}
+
+  possible-typed-array-names@1.1.0: {}
 
   postgres-array@2.0.0: {}
 
@@ -6792,7 +6994,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
   setprototypeof@1.2.0: {}
+
+  sha.js@2.4.12:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
 
   shebang-command@2.0.0:
     dependencies:
@@ -6834,6 +7051,11 @@ snapshots:
 
   slash@3.0.0: {}
 
+  sodium-native@3.4.1:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
   source-map-support@0.5.13:
     dependencies:
       buffer-from: 1.1.2
@@ -6863,6 +7085,39 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  stellar-base@8.2.2:
+    dependencies:
+      base32.js: 0.1.0
+      bignumber.js: 4.1.0
+      crc: 3.8.0
+      js-xdr: 1.3.0
+      lodash: 4.17.21
+      sha.js: 2.4.12
+      tweetnacl: 1.0.3
+    optionalDependencies:
+      sodium-native: 3.4.1
+
+  stellar-sdk@10.4.1:
+    dependencies:
+      '@types/eventsource': 1.1.15
+      '@types/node': 22.19.7
+      '@types/randombytes': 2.0.3
+      '@types/urijs': 1.19.26
+      axios: 0.25.0
+      bignumber.js: 4.1.0
+      detect-node: 2.1.0
+      es6-promise: 4.2.8
+      eventsource: 1.1.2
+      lodash: 4.17.21
+      randombytes: 2.1.0
+      stellar-base: 8.2.2
+      toml: 2.3.6
+      tslib: 1.14.1
+      urijs: 1.19.11
+      utility-types: 3.11.0
+    transitivePeerDependencies:
+      - debug
 
   streamsearch@1.1.0: {}
 
@@ -6976,6 +7231,12 @@ snapshots:
 
   tmpl@1.0.5: {}
 
+  to-buffer@1.2.2:
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -6987,6 +7248,8 @@ snapshots:
       '@borewit/text-codec': 0.2.1
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  toml@2.3.6: {}
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -7053,7 +7316,11 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tslib@1.14.1: {}
+
   tslib@2.8.1: {}
+
+  tweetnacl@1.0.3: {}
 
   type-check@0.4.0:
     dependencies:
@@ -7077,6 +7344,12 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
 
   typedarray@0.0.6: {}
 
@@ -7142,7 +7415,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  urijs@1.19.11: {}
+
   util-deprecate@1.0.2: {}
+
+  utility-types@3.11.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 
@@ -7208,6 +7485,16 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  which-typed-array@1.1.21:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:

--- a/src/wallets/wallet-creation-orchestrator.service.spec.ts
+++ b/src/wallets/wallet-creation-orchestrator.service.spec.ts
@@ -1,6 +1,7 @@
 import {
   WalletCreationOrchestrator,
   WalletOrchestrationError,
+  OrchestratorMetrics,
   CreateWalletOrchestratorRequest,
 } from './wallet-creation-orchestrator.service';
 import { WalletNetwork, WalletStatus } from './domain/wallet.model';
@@ -364,6 +365,88 @@ describe('WalletCreationOrchestrator', () => {
 
       const count = await orchestrator.cleanupStaleProvisioningWallets();
       expect(count).toBe(0);
+    });
+  });
+
+  describe('metrics logging', () => {
+    let logSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      logSpy = jest.spyOn(orchestrator['logger'], 'log').mockImplementation(() => {});
+      warnSpy = jest.spyOn(orchestrator['logger'], 'warn').mockImplementation(() => {});
+    });
+
+    const provisioningWallet = {
+      id: 'wallet-123', userId: 'user-123', publicKey: 'GABC',
+      encryptedSecret: 'enc', encryptionVersion: 1, secretVersion: 1,
+      network: WalletNetwork.TESTNET, status: WalletStatus.PROVISIONING,
+      statusReason: null, statusChangedAt: new Date(),
+      rotatedFromId: null, createdAt: new Date(), updatedAt: new Date(),
+    };
+    const activeWallet = { ...provisioningWallet, status: WalletStatus.ACTIVE };
+
+    it('should emit outcome=created with phase timings on new wallet', async () => {
+      mockPrisma.$transaction.mockImplementation(async (cb) => cb(mockPrisma as any));
+      mockPrisma.wallet.findFirst.mockResolvedValue(null);
+      mockPrisma.wallet.create.mockResolvedValue(provisioningWallet);
+      mockPrisma.wallet.update.mockResolvedValue(activeWallet);
+
+      await orchestrator.createWallet({ userId: 'user-123', network: WalletNetwork.TESTNET });
+
+      const metricsCall = logSpy.mock.calls.find(([msg]) =>
+        typeof msg === 'string' && msg.includes('[orchestrator-metrics]'),
+      );
+      expect(metricsCall).toBeDefined();
+      const line: string = metricsCall[0];
+      expect(line).toContain('outcome=created');
+      expect(line).toContain('userId=user-123');
+      expect(line).toContain('network=TESTNET');
+      expect(line).toMatch(/durationMs=\d+/);
+      expect(line).toMatch(/phase\.key-generation=\d+ms/);
+      expect(line).toMatch(/phase\.key-encryption=\d+ms/);
+      expect(line).toMatch(/phase\.wallet-persist=\d+ms/);
+      expect(line).toMatch(/phase\.wallet-activation=\d+ms/);
+    });
+
+    it('should emit outcome=existing when wallet already exists', async () => {
+      mockPrisma.$transaction.mockImplementation(async (cb) => cb(mockPrisma as any));
+      mockPrisma.wallet.findFirst.mockResolvedValue(activeWallet);
+
+      await orchestrator.createWallet({ userId: 'user-123', network: WalletNetwork.TESTNET });
+
+      const metricsCall = logSpy.mock.calls.find(([msg]) =>
+        typeof msg === 'string' && msg.includes('[orchestrator-metrics]'),
+      );
+      expect(metricsCall[0]).toContain('outcome=existing');
+    });
+
+    it('should emit outcome=failed with failedPhase via warn on error', async () => {
+      mockPrisma.$transaction.mockImplementation(async (cb) => cb(mockPrisma as any));
+      mockPrisma.wallet.findFirst.mockResolvedValue(null);
+      mockPrisma.wallet.create.mockRejectedValue(new Error('db error'));
+
+      await orchestrator.createWallet({ userId: 'user-123', network: WalletNetwork.TESTNET }).catch(() => {});
+
+      const metricsCall = warnSpy.mock.calls.find(([msg]) =>
+        typeof msg === 'string' && msg.includes('[orchestrator-metrics]'),
+      );
+      expect(metricsCall).toBeDefined();
+      const line: string = metricsCall[0];
+      expect(line).toContain('outcome=failed');
+      expect(line).toContain('failedPhase=wallet-persist');
+    });
+
+    it('should emit outcome=failed without failedPhase for non-orchestration errors', async () => {
+      mockPrisma.$transaction.mockRejectedValue(new Error('connection lost'));
+
+      await orchestrator.createWallet({ userId: 'user-123', network: WalletNetwork.TESTNET }).catch(() => {});
+
+      const metricsCall = warnSpy.mock.calls.find(([msg]) =>
+        typeof msg === 'string' && msg.includes('[orchestrator-metrics]'),
+      );
+      expect(metricsCall[0]).toContain('outcome=failed');
+      expect(metricsCall[0]).not.toContain('failedPhase=');
     });
   });
 

--- a/src/wallets/wallet-creation-orchestrator.service.spec.ts
+++ b/src/wallets/wallet-creation-orchestrator.service.spec.ts
@@ -1,12 +1,9 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ConfigService } from '@nestjs/config';
 import {
   WalletCreationOrchestrator,
+  WalletOrchestrationError,
   CreateWalletOrchestratorRequest,
 } from './wallet-creation-orchestrator.service';
-import { WalletNetwork } from './domain/wallet.model';
-import { EncryptionService } from '../encryption/encryption.service';
-import { PrismaClient } from '../generated/prisma/client';
+import { WalletNetwork, WalletStatus } from './domain/wallet.model';
 
 // Mock Prisma Client
 const mockPrisma = {
@@ -17,6 +14,7 @@ const mockPrisma = {
     update: jest.fn(),
     delete: jest.fn(),
     findMany: jest.fn(),
+    deleteMany: jest.fn(),
   },
   $transaction: jest.fn(),
 };
@@ -33,46 +31,41 @@ const mockConfigService = {
   get: jest.fn(),
 };
 
+// Mock IdempotentUserService
+const mockIdempotentUserService = {
+  findUserById: jest.fn(),
+  findUserByAuthId: jest.fn(),
+  findOrCreateUser: jest.fn(),
+};
+
 describe('WalletCreationOrchestrator', () => {
   let orchestrator: WalletCreationOrchestrator;
-  let prismaClient: jest.Mocked<PrismaClient>;
-  let encryptionService: jest.Mocked<EncryptionService>;
-  let configService: jest.Mocked<ConfigService>;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        WalletCreationOrchestrator,
-        {
-          provide: PrismaClient,
-          useValue: mockPrisma,
-        },
-        {
-          provide: EncryptionService,
-          useValue: mockEncryptionService,
-        },
-        {
-          provide: ConfigService,
-          useValue: mockConfigService,
-        },
-      ],
-    }).compile();
-
-    orchestrator = module.get<WalletCreationOrchestrator>(
-      WalletCreationOrchestrator,
-    );
-    prismaClient = module.get(PrismaClient);
-    encryptionService = module.get(EncryptionService);
-    configService = module.get(ConfigService);
-
-    // Reset all mocks
+  beforeEach(() => {
     jest.clearAllMocks();
+
+    // Directly instantiate with mocks, passing mockPrisma as the optional prismaClient arg
+    orchestrator = new WalletCreationOrchestrator(
+      mockEncryptionService as any,
+      mockConfigService as any,
+      mockIdempotentUserService as any,
+      mockPrisma as any,
+    );
 
     // Setup default mock returns
     mockEncryptionService.validateConfiguration.mockReturnValue(true);
     mockEncryptionService.encryptAndSerialize.mockReturnValue(
       'encrypted-private-key',
     );
+    mockIdempotentUserService.findUserById.mockResolvedValue({
+      id: 'user-123',
+      authId: 'auth-123',
+      email: 'test@example.com',
+      status: 'ACTIVE',
+      authProvider: 'CLERK',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
   });
 
   describe('createWallet', () => {
@@ -84,7 +77,7 @@ describe('WalletCreationOrchestrator', () => {
 
     it('should create a new wallet successfully', async () => {
       // Arrange
-      const mockWallet = {
+      const provisioningWallet = {
         id: 'wallet-123',
         userId: 'user-123',
         publicKey: 'GABC123DEF456',
@@ -92,20 +85,22 @@ describe('WalletCreationOrchestrator', () => {
         encryptionVersion: 1,
         secretVersion: 1,
         network: WalletNetwork.TESTNET,
-        status: 'ACTIVE',
+        status: WalletStatus.PROVISIONING,
         statusReason: null,
         statusChangedAt: new Date(),
         rotatedFromId: null,
         createdAt: new Date(),
         updatedAt: new Date(),
       };
+      const activeWallet = { ...provisioningWallet, status: WalletStatus.ACTIVE };
 
       mockPrisma.$transaction.mockImplementation(async (callback) => {
         return callback(mockPrisma as any);
       });
 
-      mockPrisma.wallet.findFirst.mockResolvedValue(null); // No existing wallet
-      mockPrisma.wallet.create.mockResolvedValue(mockWallet);
+      mockPrisma.wallet.findFirst.mockResolvedValue(null);
+      mockPrisma.wallet.create.mockResolvedValue(provisioningWallet);
+      mockPrisma.wallet.update.mockResolvedValue(activeWallet);
 
       // Act
       const result = await orchestrator.createWallet(createRequest);
@@ -117,30 +112,28 @@ describe('WalletCreationOrchestrator', () => {
           userId: 'user-123',
           publicKey: 'GABC123DEF456',
           network: WalletNetwork.TESTNET,
-          status: 'ACTIVE',
+          status: WalletStatus.ACTIVE,
         }),
         privateKey: expect.any(String),
         isNewWallet: true,
         idempotencyKey: 'unique-key-123',
       });
 
-      expect(mockPrisma.wallet.findFirst).toHaveBeenCalledWith({
-        where: { userId: 'user-123', network: WalletNetwork.TESTNET },
-      });
-
+      // Wallet must be created in PROVISIONING first
       expect(mockPrisma.wallet.create).toHaveBeenCalledWith({
-        data: {
+        data: expect.objectContaining({
           userId: 'user-123',
-          publicKey: expect.any(String),
-          encryptedSecret: 'encrypted-private-key',
-          network: WalletNetwork.TESTNET,
-          status: 'ACTIVE',
-          encryptionVersion: 1,
-          secretVersion: 1,
-        },
+          status: WalletStatus.PROVISIONING,
+        }),
       });
 
-      expect(encryptionService.encryptAndSerialize).toHaveBeenCalledWith(
+      // Then activated to ACTIVE in the same transaction
+      expect(mockPrisma.wallet.update).toHaveBeenCalledWith({
+        where: { id: 'wallet-123' },
+        data: expect.objectContaining({ status: WalletStatus.ACTIVE }),
+      });
+
+      expect(mockEncryptionService.encryptAndSerialize).toHaveBeenCalledWith(
         expect.any(String),
       );
     });
@@ -227,7 +220,7 @@ describe('WalletCreationOrchestrator', () => {
 
       // Act & Assert
       await expect(orchestrator.createWallet(createRequest)).rejects.toThrow(
-        'Wallet creation orchestration failed',
+        WalletOrchestrationError,
       );
     });
 
@@ -238,7 +231,7 @@ describe('WalletCreationOrchestrator', () => {
         network: WalletNetwork.TESTNET,
       };
 
-      const mockWallet = {
+      const provisioningWallet = {
         id: 'wallet-123',
         userId: 'user-123',
         publicKey: 'GABC123DEF456',
@@ -246,20 +239,22 @@ describe('WalletCreationOrchestrator', () => {
         encryptionVersion: 1,
         secretVersion: 1,
         network: WalletNetwork.TESTNET,
-        status: 'ACTIVE',
+        status: WalletStatus.PROVISIONING,
         statusReason: null,
         statusChangedAt: new Date(),
         rotatedFromId: null,
         createdAt: new Date(),
         updatedAt: new Date(),
       };
+      const activeWallet = { ...provisioningWallet, status: WalletStatus.ACTIVE };
 
       mockPrisma.$transaction.mockImplementation(async (callback) => {
         return callback(mockPrisma as any);
       });
 
       mockPrisma.wallet.findFirst.mockResolvedValue(null);
-      mockPrisma.wallet.create.mockResolvedValue(mockWallet);
+      mockPrisma.wallet.create.mockResolvedValue(provisioningWallet);
+      mockPrisma.wallet.update.mockResolvedValue(activeWallet);
 
       // Act
       const result = await orchestrator.createWallet(requestWithoutIdempotency);
@@ -274,6 +269,101 @@ describe('WalletCreationOrchestrator', () => {
         isNewWallet: true,
         idempotencyKey: undefined,
       });
+    });
+  });
+
+  describe('rollback behavior', () => {
+    const createRequest: CreateWalletOrchestratorRequest = {
+      userId: 'user-123',
+      network: WalletNetwork.TESTNET,
+    };
+
+    it('should throw WalletOrchestrationError with phase=key-encryption when encryption fails', async () => {
+      mockEncryptionService.encryptAndSerialize.mockImplementation(() => {
+        throw new Error('Encryption key unavailable');
+      });
+
+      mockPrisma.$transaction.mockImplementation(async (callback) =>
+        callback(mockPrisma as any),
+      );
+      mockPrisma.wallet.findFirst.mockResolvedValue(null);
+
+      const err = await orchestrator.createWallet(createRequest).catch((e) => e);
+      expect(err).toBeInstanceOf(WalletOrchestrationError);
+      expect(err.phase).toBe('key-encryption');
+    });
+
+    it('should throw WalletOrchestrationError with phase=wallet-persist when DB create fails', async () => {
+      mockPrisma.$transaction.mockImplementation(async (callback) =>
+        callback(mockPrisma as any),
+      );
+      mockPrisma.wallet.findFirst.mockResolvedValue(null);
+      mockPrisma.wallet.create.mockRejectedValue(new Error('DB write error'));
+
+      const err = await orchestrator.createWallet(createRequest).catch((e) => e);
+      expect(err).toBeInstanceOf(WalletOrchestrationError);
+      expect(err.phase).toBe('wallet-persist');
+    });
+
+    it('should throw WalletOrchestrationError with phase=wallet-activation when activation update fails', async () => {
+      const provisioningWallet = {
+        id: 'wallet-123',
+        userId: 'user-123',
+        publicKey: 'GABC123',
+        encryptedSecret: 'enc',
+        encryptionVersion: 1,
+        secretVersion: 1,
+        network: WalletNetwork.TESTNET,
+        status: WalletStatus.PROVISIONING,
+        statusReason: null,
+        statusChangedAt: new Date(),
+        rotatedFromId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockPrisma.$transaction.mockImplementation(async (callback) =>
+        callback(mockPrisma as any),
+      );
+      mockPrisma.wallet.findFirst.mockResolvedValue(null);
+      mockPrisma.wallet.create.mockResolvedValue(provisioningWallet);
+      mockPrisma.wallet.update.mockRejectedValue(new Error('DB update error'));
+
+      const err = await orchestrator.createWallet(createRequest).catch((e) => e);
+      expect(err).toBeInstanceOf(WalletOrchestrationError);
+      expect(err.phase).toBe('wallet-activation');
+    });
+
+    it('should preserve original error as cause on WalletOrchestrationError', async () => {
+      const originalError = new Error('original DB error');
+      mockPrisma.$transaction.mockRejectedValue(originalError);
+
+      const err = await orchestrator.createWallet(createRequest).catch((e) => e);
+      expect(err).toBeInstanceOf(WalletOrchestrationError);
+      expect(err.cause).toBe(originalError);
+    });
+  });
+
+  describe('cleanupStaleProvisioningWallets', () => {
+    it('should delete PROVISIONING wallets older than the cutoff', async () => {
+      mockPrisma.wallet.deleteMany.mockResolvedValue({ count: 3 });
+
+      const count = await orchestrator.cleanupStaleProvisioningWallets(300_000);
+
+      expect(count).toBe(3);
+      expect(mockPrisma.wallet.deleteMany).toHaveBeenCalledWith({
+        where: {
+          status: WalletStatus.PROVISIONING,
+          createdAt: { lt: expect.any(Date) },
+        },
+      });
+    });
+
+    it('should return 0 when no stale wallets exist', async () => {
+      mockPrisma.wallet.deleteMany.mockResolvedValue({ count: 0 });
+
+      const count = await orchestrator.cleanupStaleProvisioningWallets();
+      expect(count).toBe(0);
     });
   });
 

--- a/src/wallets/wallet-creation-orchestrator.service.ts
+++ b/src/wallets/wallet-creation-orchestrator.service.ts
@@ -20,6 +20,19 @@ export type OrchestrationPhase =
   | 'wallet-activation'
   | 'idempotency-store';
 
+export type OrchestrationOutcome = 'created' | 'existing' | 'idempotent' | 'failed';
+
+export interface OrchestratorMetrics {
+  userId: string;
+  network: WalletNetwork;
+  outcome: OrchestrationOutcome;
+  durationMs: number;
+  /** Phase timings in milliseconds, only present for new wallet creation. */
+  phases?: Partial<Record<OrchestrationPhase, number>>;
+  /** Set when outcome is 'failed'. */
+  failedPhase?: OrchestrationPhase;
+}
+
 export class WalletOrchestrationError extends Error {
   constructor(
     message: string,
@@ -131,6 +144,12 @@ export class WalletCreationOrchestrator {
             this.logger.log(
               `Returning cached result for idempotency key: ${request.idempotencyKey}`,
             );
+            this.emitMetrics({
+              userId: request.userId,
+              network: request.network,
+              outcome: 'idempotent',
+              durationMs: Date.now() - startTime,
+            });
             return existingResult;
           }
         }
@@ -140,6 +159,12 @@ export class WalletCreationOrchestrator {
           this.logger.log(
             `User ${request.userId} already has wallet on ${request.network}`,
           );
+          this.emitMetrics({
+            userId: request.userId,
+            network: request.network,
+            outcome: 'existing',
+            durationMs: Date.now() - startTime,
+          });
           return {
             wallet: context.existingWallet,
             privateKey: '',
@@ -167,16 +192,30 @@ export class WalletCreationOrchestrator {
           );
         }
 
+        this.emitMetrics({
+          userId: request.userId,
+          network: request.network,
+          outcome: 'created',
+          durationMs: Date.now() - startTime,
+          phases: newWallet.phaseTimings,
+        });
+
         return txResult;
       });
 
-      const duration = Date.now() - startTime;
-      this.logger.log(
-        `Wallet creation orchestration completed in ${duration}ms for user ${request.userId}`,
-      );
-
       return result;
     } catch (error) {
+      const failedPhase =
+        error instanceof WalletOrchestrationError ? error.phase : undefined;
+
+      this.emitMetrics({
+        userId: request.userId,
+        network: request.network,
+        outcome: 'failed',
+        durationMs: Date.now() - startTime,
+        failedPhase,
+      });
+
       this.logger.error(
         `Wallet creation orchestration failed for user ${request.userId}:`,
         error,
@@ -195,6 +234,27 @@ export class WalletCreationOrchestrator {
         'wallet-persist',
         error,
       );
+    }
+  }
+
+  private emitMetrics(metrics: OrchestratorMetrics): void {
+    const parts = [
+      `outcome=${metrics.outcome}`,
+      `userId=${metrics.userId}`,
+      `network=${metrics.network}`,
+      `durationMs=${metrics.durationMs}`,
+    ];
+    if (metrics.failedPhase) parts.push(`failedPhase=${metrics.failedPhase}`);
+    if (metrics.phases) {
+      for (const [phase, ms] of Object.entries(metrics.phases)) {
+        parts.push(`phase.${phase}=${ms}ms`);
+      }
+    }
+    const line = `[orchestrator-metrics] ${parts.join(' ')}`;
+    if (metrics.outcome === 'failed') {
+      this.logger.warn(line);
+    } else {
+      this.logger.log(line);
     }
   }
 
@@ -286,13 +346,16 @@ export class WalletCreationOrchestrator {
   private async createNewWallet(
     context: OrchestrationContext,
     tx: any,
-  ): Promise<{ wallet: Wallet; privateKey: string }> {
+  ): Promise<{ wallet: Wallet; privateKey: string; phaseTimings: Partial<Record<OrchestrationPhase, number>> }> {
     const { request } = context;
+    const phaseTimings: Partial<Record<OrchestrationPhase, number>> = {};
 
     // Phase: key-generation
     let keyPair: { publicKey: string; privateKey: string };
     try {
+      const t = Date.now();
       keyPair = this.generateStellarKeyPair();
+      phaseTimings['key-generation'] = Date.now() - t;
     } catch (error) {
       throw new WalletOrchestrationError(
         'Key generation failed',
@@ -304,9 +367,11 @@ export class WalletCreationOrchestrator {
     // Phase: key-encryption
     let encryptedSecret: string;
     try {
+      const t = Date.now();
       encryptedSecret = this.encryptionService.encryptAndSerialize(
         keyPair.privateKey,
       );
+      phaseTimings['key-encryption'] = Date.now() - t;
     } catch (error) {
       throw new WalletOrchestrationError(
         'Key encryption failed',
@@ -318,6 +383,7 @@ export class WalletCreationOrchestrator {
     // Phase: wallet-persist (PROVISIONING)
     let provisioningWallet: any;
     try {
+      const t = Date.now();
       provisioningWallet = await tx.wallet.create({
         data: {
           userId: request.userId,
@@ -329,6 +395,7 @@ export class WalletCreationOrchestrator {
           secretVersion: 1,
         },
       });
+      phaseTimings['wallet-persist'] = Date.now() - t;
     } catch (error) {
       throw new WalletOrchestrationError(
         'Wallet persist failed',
@@ -340,6 +407,7 @@ export class WalletCreationOrchestrator {
     // Phase: wallet-activation (ACTIVE) — still inside the same transaction
     let activatedWallet: any;
     try {
+      const t = Date.now();
       activatedWallet = await tx.wallet.update({
         where: { id: provisioningWallet.id },
         data: {
@@ -347,6 +415,7 @@ export class WalletCreationOrchestrator {
           statusChangedAt: new Date(),
         },
       });
+      phaseTimings['wallet-activation'] = Date.now() - t;
     } catch (error) {
       throw new WalletOrchestrationError(
         'Wallet activation failed',
@@ -362,6 +431,7 @@ export class WalletCreationOrchestrator {
     return {
       wallet: this.mapPrismaWalletToDomain(activatedWallet),
       privateKey: keyPair.privateKey,
+      phaseTimings,
     };
   }
 

--- a/src/wallets/wallet-creation-orchestrator.service.ts
+++ b/src/wallets/wallet-creation-orchestrator.service.ts
@@ -11,6 +11,26 @@ import { EncryptionService } from '../encryption/encryption.service';
 import { IdempotentUserService } from '../users/idempotent-user.service';
 import * as crypto from 'crypto';
 
+export type OrchestrationPhase =
+  | 'user-resolution'
+  | 'idempotency-check'
+  | 'key-generation'
+  | 'key-encryption'
+  | 'wallet-persist'
+  | 'wallet-activation'
+  | 'idempotency-store';
+
+export class WalletOrchestrationError extends Error {
+  constructor(
+    message: string,
+    public readonly phase: OrchestrationPhase,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'WalletOrchestrationError';
+  }
+}
+
 export interface User {
   id: string;
   authId: string;
@@ -60,8 +80,9 @@ export class WalletCreationOrchestrator {
     private encryptionService: EncryptionService,
     private configService: ConfigService,
     private idempotentUserService: IdempotentUserService,
+    prismaClient?: PrismaClient,
   ) {
-    this.prisma = new PrismaClient({} as any);
+    this.prisma = prismaClient ?? new PrismaClient(undefined);
   }
 
   async onModuleInit() {
@@ -77,7 +98,15 @@ export class WalletCreationOrchestrator {
   }
 
   /**
-   * Orchestrates the complete wallet creation flow with atomic operations and idempotency
+   * Orchestrates the complete wallet creation flow with atomic operations and idempotency.
+   *
+   * Rollback strategy:
+   * - Wallets are first written in PROVISIONING status inside a DB transaction.
+   * - On success the same transaction updates the wallet to ACTIVE.
+   * - If any step throws, Prisma rolls back the entire transaction automatically,
+   *   leaving no partial wallet record in the database.
+   * - Stale PROVISIONING wallets (from crashed processes) can be cleaned up via
+   *   `cleanupStaleProvisioningWallets`.
    */
   async createWallet(
     request: CreateWalletOrchestratorRequest,
@@ -88,11 +117,11 @@ export class WalletCreationOrchestrator {
     );
 
     try {
-      // Use database transaction for atomicity
       const result = await this.prisma.$transaction(async (tx) => {
+        // --- Phase: user-resolution ---
         const context = await this.buildOrchestrationContext(request, tx);
 
-        // Check idempotency if key provided
+        // --- Phase: idempotency-check ---
         if (request.idempotencyKey) {
           const existingResult = await this.checkIdempotency(
             request.idempotencyKey,
@@ -113,28 +142,32 @@ export class WalletCreationOrchestrator {
           );
           return {
             wallet: context.existingWallet,
-            privateKey: '', // Empty for existing wallets
+            privateKey: '',
             isNewWallet: false,
             idempotencyKey: request.idempotencyKey,
           };
         }
 
-        // Create new wallet atomically
+        // --- Phases: key-generation → key-encryption → wallet-persist → wallet-activation ---
         const newWallet = await this.createNewWallet(context, tx);
 
-        const result: WalletOrchestrationResult = {
+        const txResult: WalletOrchestrationResult = {
           wallet: newWallet.wallet,
           privateKey: newWallet.privateKey,
           isNewWallet: true,
           idempotencyKey: request.idempotencyKey,
         };
 
-        // Store idempotency record if key provided
+        // --- Phase: idempotency-store ---
         if (request.idempotencyKey) {
-          await this.storeIdempotencyRecord(request.idempotencyKey, result, tx);
+          await this.storeIdempotencyRecord(
+            request.idempotencyKey,
+            txResult,
+            tx,
+          );
         }
 
-        return result;
+        return txResult;
       });
 
       const duration = Date.now() - startTime;
@@ -149,12 +182,40 @@ export class WalletCreationOrchestrator {
         error,
       );
 
-      if (error instanceof ConflictException) {
+      if (error instanceof ConflictException || error instanceof NotFoundException) {
         throw error;
       }
 
-      throw new Error('Wallet creation orchestration failed');
+      if (error instanceof WalletOrchestrationError) {
+        throw error;
+      }
+
+      throw new WalletOrchestrationError(
+        'Wallet creation orchestration failed',
+        'wallet-persist',
+        error,
+      );
     }
+  }
+
+  /**
+   * Removes stale PROVISIONING wallets older than `olderThanMs` milliseconds.
+   * Call this from a scheduled job or on startup to recover from crashed orchestrations.
+   */
+  async cleanupStaleProvisioningWallets(olderThanMs = 5 * 60 * 1000): Promise<number> {
+    const cutoff = new Date(Date.now() - olderThanMs);
+    const { count } = await this.prisma.wallet.deleteMany({
+      where: {
+        status: WalletStatus.PROVISIONING,
+        createdAt: { lt: cutoff },
+      },
+    });
+    if (count > 0) {
+      this.logger.warn(
+        `Cleaned up ${count} stale PROVISIONING wallet(s) older than ${olderThanMs}ms`,
+      );
+    }
+    return count;
   }
 
   /**
@@ -216,7 +277,11 @@ export class WalletCreationOrchestrator {
   }
 
   /**
-   * Creates a new wallet with encrypted private key storage
+   * Creates a new wallet using a two-phase write inside the active transaction:
+   *   1. Insert with status PROVISIONING (rollback-safe sentinel).
+   *   2. Activate to ACTIVE in the same transaction.
+   *
+   * If any step throws, Prisma rolls back both writes automatically.
    */
   private async createNewWallet(
     context: OrchestrationContext,
@@ -224,39 +289,80 @@ export class WalletCreationOrchestrator {
   ): Promise<{ wallet: Wallet; privateKey: string }> {
     const { request } = context;
 
-    // Generate new keypair
-    const keyPair = this.generateStellarKeyPair();
-
-    // Encrypt the private key before storage
-    const encryptedSecret = this.encryptionService.encryptAndSerialize(
-      keyPair.privateKey,
-    );
-
+    // Phase: key-generation
+    let keyPair: { publicKey: string; privateKey: string };
     try {
-      const createdWallet = await tx.wallet.create({
+      keyPair = this.generateStellarKeyPair();
+    } catch (error) {
+      throw new WalletOrchestrationError(
+        'Key generation failed',
+        'key-generation',
+        error,
+      );
+    }
+
+    // Phase: key-encryption
+    let encryptedSecret: string;
+    try {
+      encryptedSecret = this.encryptionService.encryptAndSerialize(
+        keyPair.privateKey,
+      );
+    } catch (error) {
+      throw new WalletOrchestrationError(
+        'Key encryption failed',
+        'key-encryption',
+        error,
+      );
+    }
+
+    // Phase: wallet-persist (PROVISIONING)
+    let provisioningWallet: any;
+    try {
+      provisioningWallet = await tx.wallet.create({
         data: {
           userId: request.userId,
           publicKey: keyPair.publicKey,
           encryptedSecret,
           network: request.network,
-          status: 'ACTIVE',
+          status: WalletStatus.PROVISIONING,
           encryptionVersion: 1,
           secretVersion: 1,
         },
       });
-
-      this.logger.log(
-        `Created new wallet for user ${request.userId} on ${request.network}`,
-      );
-
-      return {
-        wallet: this.mapPrismaWalletToDomain(createdWallet),
-        privateKey: keyPair.privateKey,
-      };
     } catch (error) {
-      this.logger.error('Failed to create wallet in transaction:', error);
-      throw new Error('Wallet creation failed');
+      throw new WalletOrchestrationError(
+        'Wallet persist failed',
+        'wallet-persist',
+        error,
+      );
     }
+
+    // Phase: wallet-activation (ACTIVE) — still inside the same transaction
+    let activatedWallet: any;
+    try {
+      activatedWallet = await tx.wallet.update({
+        where: { id: provisioningWallet.id },
+        data: {
+          status: WalletStatus.ACTIVE,
+          statusChangedAt: new Date(),
+        },
+      });
+    } catch (error) {
+      throw new WalletOrchestrationError(
+        'Wallet activation failed',
+        'wallet-activation',
+        error,
+      );
+    }
+
+    this.logger.log(
+      `Created and activated wallet for user ${request.userId} on ${request.network}`,
+    );
+
+    return {
+      wallet: this.mapPrismaWalletToDomain(activatedWallet),
+      privateKey: keyPair.privateKey,
+    };
   }
 
   /**


### PR DESCRIPTION
Adds structured rollback to the wallet creation orchestrator so failures at any stage leave no partial state in the database.

What changed

- WalletOrchestrationError — typed error with phase (key-generation, key-encryption, wallet-persist, wallet-activation, etc.) and cause chain, replacing the previous generic 
Error
- Two-phase write: wallet is inserted as PROVISIONING then updated to ACTIVE within the same Prisma transaction — any failure auto-rolls back both writes, leaving no orphaned 
record
- cleanupStaleProvisioningWallets(olderThanMs?) — removes PROVISIONING wallets older than a threshold (default 5 min) for crash recovery; call from a startup hook or scheduled 
job
- Constructor now accepts an optional PrismaClient for proper unit testability

Tests

- All 17 unit tests pass
- New rollback behavior suite covers: encryption failure, DB persist failure, activation failure, and original error preserved as cause
- New cleanupStaleProvisioningWallets suite covers cutoff query and zero-count case
- No regressions in related suites

Closes #199 