### PR TITLE
feat(transactions): add idempotency key support

### DIFF
--- a/prisma/migrations/20260601000000_add_transaction_idempotency_key/migration.sql
+++ b/prisma/migrations/20260601000000_add_transaction_idempotency_key/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Transaction" ADD COLUMN "idempotencyKey" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Transaction_idempotencyKey_key" ON "Transaction"("idempotencyKey");
+
+-- CreateIndex
+CREATE INDEX "Transaction_idempotencyKey_idx" ON "Transaction"("idempotencyKey");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -623,6 +623,9 @@ model Transaction {
   
   /// Metadata for future webhooks and analytics
   metadata Json? // Flexible JSON for additional transaction context
+
+  /// Client-supplied idempotency key to prevent duplicate submissions
+  idempotencyKey String? @unique
   
   /// Operational metadata
   createdAt DateTime @default(now())
@@ -636,4 +639,5 @@ model Transaction {
   @@index([stellarHash])
   @@index([stellarLedger])
   @@index([createdAt])
+  @@index([idempotencyKey])
 }

--- a/src/transactions/dto/create-transaction.dto.ts
+++ b/src/transactions/dto/create-transaction.dto.ts
@@ -10,4 +10,6 @@ export class CreateTransactionDto {
   senderWalletId: string;
   receiverWalletId?: string;
   metadata?: Record<string, any>;
+  /** Optional client-supplied key to prevent duplicate submissions */
+  idempotencyKey?: string;
 }

--- a/src/transactions/entities/transaction.entity.ts
+++ b/src/transactions/entities/transaction.entity.ts
@@ -30,6 +30,8 @@ export class Transaction {
 
   metadata?: Record<string, any> | null;
 
+  idempotencyKey?: string | null;
+
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/transactions/transactions.service.spec.ts
+++ b/src/transactions/transactions.service.spec.ts
@@ -1,0 +1,210 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { TransactionsService } from './transactions.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { TransactionStatus } from './domain/transaction.model';
+
+const mockWallet = { id: 'wallet-1' };
+const mockTransaction = {
+  id: 'tx-1',
+  amount: '100',
+  assetType: 'NATIVE',
+  assetCode: null,
+  assetIssuer: null,
+  senderWalletId: 'wallet-1',
+  receiverWalletId: null,
+  status: TransactionStatus.PENDING,
+  stellarHash: null,
+  stellarLedger: null,
+  stellarFee: null,
+  statusChangedAt: new Date(),
+  statusReason: null,
+  submittedAt: null,
+  confirmedAt: null,
+  failedAt: null,
+  metadata: null,
+  idempotencyKey: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('TransactionsService', () => {
+  let service: TransactionsService;
+  let prisma: any;
+
+  beforeEach(async () => {
+    prisma = {
+      wallet: { findUnique: jest.fn() },
+      transaction: {
+        create: jest.fn(),
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        update: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TransactionsService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<TransactionsService>(TransactionsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    const baseDto = {
+      amount: '100',
+      asset: { type: 'NATIVE' },
+      senderWalletId: 'wallet-1',
+    };
+
+    it('creates a transaction without idempotency key', async () => {
+      prisma.wallet.findUnique.mockResolvedValue(mockWallet);
+      prisma.transaction.create.mockResolvedValue(mockTransaction);
+
+      const result = await service.create(baseDto);
+
+      expect(prisma.transaction.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          amount: '100',
+          assetType: 'NATIVE',
+          status: TransactionStatus.PENDING,
+          idempotencyKey: null,
+        }),
+      });
+      expect(result.id).toBe('tx-1');
+    });
+
+    it('returns existing transaction on idempotency key hit', async () => {
+      const existingTx = { ...mockTransaction, idempotencyKey: 'key-abc' };
+      prisma.transaction.findUnique.mockResolvedValue(existingTx);
+
+      const result = await service.create({
+        ...baseDto,
+        idempotencyKey: 'key-abc',
+      });
+
+      // Should not validate wallets or create a new transaction
+      expect(prisma.wallet.findUnique).not.toHaveBeenCalled();
+      expect(prisma.transaction.create).not.toHaveBeenCalled();
+      expect(result.id).toBe('tx-1');
+      expect(result.idempotencyKey).toBe('key-abc');
+    });
+
+    it('creates a new transaction when idempotency key is not yet used', async () => {
+      const newTx = { ...mockTransaction, idempotencyKey: 'key-new' };
+      prisma.transaction.findUnique.mockResolvedValue(null); // no existing tx
+      prisma.wallet.findUnique.mockResolvedValue(mockWallet);
+      prisma.transaction.create.mockResolvedValue(newTx);
+
+      const result = await service.create({
+        ...baseDto,
+        idempotencyKey: 'key-new',
+      });
+
+      expect(prisma.transaction.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ idempotencyKey: 'key-new' }),
+      });
+      expect(result.idempotencyKey).toBe('key-new');
+    });
+
+    it('resolves race condition (P2002) by returning the winning transaction', async () => {
+      const raceTx = { ...mockTransaction, idempotencyKey: 'key-race' };
+      prisma.transaction.findUnique
+        .mockResolvedValueOnce(null) // initial check: no existing tx
+        .mockResolvedValueOnce(raceTx); // post-P2002 lookup
+      prisma.wallet.findUnique.mockResolvedValue(mockWallet);
+      prisma.transaction.create.mockRejectedValue({
+        code: 'P2002',
+        meta: { target: ['idempotencyKey'] },
+      });
+
+      const result = await service.create({
+        ...baseDto,
+        idempotencyKey: 'key-race',
+      });
+
+      expect(result.id).toBe('tx-1');
+      expect(result.idempotencyKey).toBe('key-race');
+    });
+
+    it('re-throws non-idempotency P2002 errors', async () => {
+      prisma.transaction.findUnique.mockResolvedValue(null);
+      prisma.wallet.findUnique.mockResolvedValue(mockWallet);
+      const dbError = { code: 'P2002', meta: { target: ['stellarHash'] } };
+      prisma.transaction.create.mockRejectedValue(dbError);
+
+      await expect(
+        service.create({ ...baseDto, idempotencyKey: 'key-x' }),
+      ).rejects.toEqual(dbError);
+    });
+
+    it('throws NotFoundException when sender wallet does not exist', async () => {
+      prisma.transaction.findUnique.mockResolvedValue(null);
+      prisma.wallet.findUnique.mockResolvedValue(null);
+
+      await expect(service.create(baseDto)).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when receiver wallet does not exist', async () => {
+      prisma.transaction.findUnique.mockResolvedValue(null);
+      prisma.wallet.findUnique
+        .mockResolvedValueOnce(mockWallet) // sender found
+        .mockResolvedValueOnce(null); // receiver not found
+
+      await expect(
+        service.create({ ...baseDto, receiverWalletId: 'wallet-missing' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('throws BadRequestException for invalid status transition', async () => {
+      prisma.transaction.findUnique.mockResolvedValue({
+        ...mockTransaction,
+        status: TransactionStatus.CONFIRMED,
+      });
+
+      await expect(
+        service.updateStatus('tx-1', { status: TransactionStatus.PENDING }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('updates status from PENDING to SUBMITTED', async () => {
+      const updated = {
+        ...mockTransaction,
+        status: TransactionStatus.SUBMITTED,
+        submittedAt: new Date(),
+      };
+      prisma.transaction.findUnique.mockResolvedValue(mockTransaction);
+      prisma.transaction.update.mockResolvedValue(updated);
+
+      const result = await service.updateStatus('tx-1', {
+        status: TransactionStatus.SUBMITTED,
+      });
+
+      expect(result.status).toBe(TransactionStatus.SUBMITTED);
+    });
+  });
+
+  describe('findOne', () => {
+    it('throws NotFoundException when transaction does not exist', async () => {
+      prisma.transaction.findUnique.mockResolvedValue(null);
+      await expect(service.findOne('missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('returns the transaction when found', async () => {
+      prisma.transaction.findUnique.mockResolvedValue(mockTransaction);
+      const result = await service.findOne('tx-1');
+      expect(result.id).toBe('tx-1');
+    });
+  });
+});

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -25,13 +25,34 @@ export class TransactionsService {
   constructor(private readonly prisma: PrismaService) {}
 
   /**
-   * Create a new transaction in PENDING state
+   * Create a new transaction in PENDING state.
+   * If an idempotencyKey is supplied and a transaction with that key already
+   * exists, the existing transaction is returned without creating a duplicate.
    */
   async create(
     createTransactionDto: CreateTransactionDto,
   ): Promise<TransactionEntity> {
-    const { amount, asset, senderWalletId, receiverWalletId, metadata } =
-      createTransactionDto;
+    const {
+      amount,
+      asset,
+      senderWalletId,
+      receiverWalletId,
+      metadata,
+      idempotencyKey,
+    } = createTransactionDto;
+
+    // Idempotency check: return existing transaction if key already used
+    if (idempotencyKey) {
+      const existing = await this.prisma.transaction.findUnique({
+        where: { idempotencyKey },
+      });
+      if (existing) {
+        this.logger.log(
+          `Idempotency hit for key ${idempotencyKey}, returning existing transaction ${existing.id}`,
+        );
+        return this.mapPrismaToEntity(existing);
+      }
+    }
 
     // Validate wallets exist
     const senderWallet = await this.prisma.wallet.findUnique({
@@ -55,22 +76,43 @@ export class TransactionsService {
     }
 
     // Create transaction in database
-    const created = await this.prisma.transaction.create({
-      data: {
-        amount,
-        assetType: asset.type,
-        assetCode: asset.code ?? null,
-        assetIssuer: asset.issuer ?? null,
-        senderWalletId,
-        receiverWalletId: receiverWalletId ?? null,
-        status: TransactionStatus.PENDING,
-        metadata: metadata ?? null,
-      },
-    });
+    try {
+      const created = await this.prisma.transaction.create({
+        data: {
+          amount,
+          assetType: asset.type,
+          assetCode: asset.code ?? null,
+          assetIssuer: asset.issuer ?? null,
+          senderWalletId,
+          receiverWalletId: receiverWalletId ?? null,
+          status: TransactionStatus.PENDING,
+          metadata: metadata ?? null,
+          idempotencyKey: idempotencyKey ?? null,
+        },
+      });
 
-    this.logger.log(`Created transaction ${created.id} in PENDING state`);
+      this.logger.log(`Created transaction ${created.id} in PENDING state`);
 
-    return this.mapPrismaToEntity(created);
+      return this.mapPrismaToEntity(created);
+    } catch (error: any) {
+      // Handle race condition: two concurrent requests with the same idempotency key
+      if (
+        idempotencyKey &&
+        error?.code === 'P2002' &&
+        error?.meta?.target?.includes('idempotencyKey')
+      ) {
+        const existing = await this.prisma.transaction.findUnique({
+          where: { idempotencyKey },
+        });
+        if (existing) {
+          this.logger.log(
+            `Idempotency race resolved for key ${idempotencyKey}, returning transaction ${existing.id}`,
+          );
+          return this.mapPrismaToEntity(existing);
+        }
+      }
+      throw error;
+    }
   }
 
   /**
@@ -240,6 +282,7 @@ export class TransactionsService {
       confirmedAt: prismaTransaction.confirmedAt,
       failedAt: prismaTransaction.failedAt,
       metadata: prismaTransaction.metadata,
+      idempotencyKey: prismaTransaction.idempotencyKey,
       createdAt: prismaTransaction.createdAt,
       updatedAt: prismaTransaction.updatedAt,
     };


### PR DESCRIPTION
feat(transactions): Add transaction idempotency key
  
  Prevents duplicate transactions when clients retry POST /transactions due to network failures
  or timeouts.
  
  Changes
  
  - Added optional idempotencyKey field to CreateTransactionDto and the Transaction entity
  - Added idempotencyKey column to the Transaction table (unique constraint) with migration
  - TransactionsService.create() checks for an existing transaction by key before creating —
  returns the original on a hit, skips wallet validation and DB write
  - Handles concurrent duplicate requests via Prisma P2002 unique constraint violation recovery
  - Added unit tests covering: idempotency hit, race condition resolution, new key creation,
  non-idempotency errors, and existing regression cases
  
  Behavior
  
  - No idempotencyKey supplied → existing behavior unchanged
  - Same key submitted twice → second request returns the original transaction (200, no duplicate
  created)
  - Two concurrent requests with the same key → one wins at the DB level, both callers receive
  the same transaction
  
  Testing
  
  - src/transactions/transactions.service.spec.ts — 8 new unit tests
closes #220