### PR TITLE
Feature/auth metrics and env validation

### DIFF
--- a/src/auth/auth-metrics.controller.spec.ts
+++ b/src/auth/auth-metrics.controller.spec.ts
@@ -1,0 +1,87 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthMetricsController } from './auth-metrics.controller';
+import { AuthMetricsService, AuthMetricsSnapshot } from './auth-metrics.service';
+
+const makeSnapshot = (overrides: Partial<AuthMetricsSnapshot> = {}): AuthMetricsSnapshot => ({
+  totalAttempts: 0,
+  outcomes: {
+    success_new_user: 0,
+    success_returning_user: 0,
+    failure_invalid_payload: 0,
+    failure_user_inactive: 0,
+    failure_wallet_error: 0,
+    failure_unknown: 0,
+  },
+  rateLimitHits: 0,
+  averageLatencyMs: 0,
+  p95LatencyMs: 0,
+  lastResetAt: new Date('2026-01-01T00:00:00Z'),
+  ...overrides,
+});
+
+describe('AuthMetricsController', () => {
+  let controller: AuthMetricsController;
+  let metricsService: jest.Mocked<AuthMetricsService>;
+
+  beforeEach(async () => {
+    metricsService = {
+      recordAttempt: jest.fn(),
+      recordRateLimitHit: jest.fn(),
+      getSnapshot: jest.fn(),
+      reset: jest.fn(),
+    } as unknown as jest.Mocked<AuthMetricsService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthMetricsController],
+      providers: [{ provide: AuthMetricsService, useValue: metricsService }],
+    }).compile();
+
+    controller = module.get(AuthMetricsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getMetrics()', () => {
+    it('delegates to AuthMetricsService.getSnapshot()', () => {
+      const snap = makeSnapshot({ totalAttempts: 42, rateLimitHits: 3 });
+      metricsService.getSnapshot.mockReturnValue(snap);
+
+      const result = controller.getMetrics();
+
+      expect(metricsService.getSnapshot).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(snap);
+    });
+
+    it('returns a snapshot with all expected fields', () => {
+      const snap = makeSnapshot({
+        totalAttempts: 10,
+        averageLatencyMs: 120,
+        p95LatencyMs: 300,
+        outcomes: {
+          success_new_user: 3,
+          success_returning_user: 5,
+          failure_invalid_payload: 1,
+          failure_user_inactive: 0,
+          failure_wallet_error: 0,
+          failure_unknown: 1,
+        },
+      });
+      metricsService.getSnapshot.mockReturnValue(snap);
+
+      const result = controller.getMetrics();
+      expect(result.totalAttempts).toBe(10);
+      expect(result.averageLatencyMs).toBe(120);
+      expect(result.p95LatencyMs).toBe(300);
+      expect(result.outcomes.success_new_user).toBe(3);
+    });
+
+    it('returns zero-state snapshot when no auth has occurred', () => {
+      metricsService.getSnapshot.mockReturnValue(makeSnapshot());
+      const result = controller.getMetrics();
+      expect(result.totalAttempts).toBe(0);
+      expect(result.rateLimitHits).toBe(0);
+    });
+  });
+});

--- a/src/auth/auth-metrics.controller.ts
+++ b/src/auth/auth-metrics.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
+import { AuthMetricsService, AuthMetricsSnapshot } from './auth-metrics.service';
+
+/**
+ * Exposes read-only auth metrics.
+ *
+ * Route: GET /auth/metrics
+ *
+ * This endpoint requires a valid API key (inherits the global ApiKeyGuard).
+ * It is intentionally NOT marked @Public() so that raw metric data is not
+ * accessible without authentication.
+ */
+@Controller('auth')
+export class AuthMetricsController {
+  constructor(private readonly authMetrics: AuthMetricsService) {}
+
+  /**
+   * Returns a point-in-time snapshot of auth instrumentation counters.
+   *
+   * Response shape mirrors {@link AuthMetricsSnapshot}.
+   */
+  @Get('metrics')
+  @HttpCode(HttpStatus.OK)
+  getMetrics(): AuthMetricsSnapshot {
+    return this.authMetrics.getSnapshot();
+  }
+}

--- a/src/auth/auth-metrics.integration.spec.ts
+++ b/src/auth/auth-metrics.integration.spec.ts
@@ -1,0 +1,265 @@
+/**
+ * Auth Metrics Integration Spec
+ *
+ * Wires the real AuthOrchestrator + AuthMetricsService together with
+ * mocked collaborators to verify that metric counters are updated
+ * for every meaningful auth outcome.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { AuthOrchestrator } from './auth-orchestrator.service';
+import { AuthMetricsService } from './auth-metrics.service';
+import { IdempotentUserService } from '../users/idempotent-user.service';
+import { WalletCreationOrchestrator } from '../wallets/wallet-creation-orchestrator.service';
+import { WalletNetwork, WalletStatus } from '../wallets/domain/wallet.model';
+import { IdempotencyService } from '../common/idempotency/idempotency.service';
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const NOW = new Date('2026-01-01T00:00:00.000Z');
+
+const makeUser = (overrides: Record<string, unknown> = {}) => ({
+  id: 'user-abc',
+  authId: 'auth-abc',
+  email: 'user@example.com',
+  displayName: 'Test User',
+  status: 'ACTIVE',
+  authProvider: 'GOOGLE',
+  lastLoginAt: NOW,
+  createdAt: NOW,
+  updatedAt: NOW,
+  ...overrides,
+});
+
+const makeWallet = (overrides: Record<string, unknown> = {}) => ({
+  id: 'wallet-abc',
+  userId: 'user-abc',
+  publicKey: 'GABC1234567890',
+  encryptedSecret: 'enc-secret',
+  encryptionVersion: 1,
+  secretVersion: 1,
+  network: WalletNetwork.TESTNET,
+  status: WalletStatus.ACTIVE,
+  statusChangedAt: NOW,
+  createdAt: NOW,
+  updatedAt: NOW,
+  rotatedFromId: null,
+  statusReason: null,
+  ...overrides,
+});
+
+// ─── Test suite ─────────────────────────────────────────────────────────────
+
+describe('AuthOrchestrator — metrics integration', () => {
+  let orchestrator: AuthOrchestrator;
+  let metricsService: AuthMetricsService;
+  let userService: jest.Mocked<
+    Pick<IdempotentUserService, 'findOrCreateUser' | 'findUserByAuthId'>
+  >;
+  let walletOrchestrator: jest.Mocked<
+    Pick<WalletCreationOrchestrator, 'getWalletByUser' | 'createWallet'>
+  >;
+
+  beforeEach(async () => {
+    userService = {
+      findOrCreateUser: jest.fn(),
+      findUserByAuthId: jest.fn(),
+    };
+
+    walletOrchestrator = {
+      getWalletByUser: jest.fn(),
+      createWallet: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthOrchestrator,
+        AuthMetricsService,
+        { provide: IdempotentUserService, useValue: userService },
+        { provide: WalletCreationOrchestrator, useValue: walletOrchestrator },
+        {
+          provide: IdempotencyService,
+          useValue: {
+            getCachedResponse: jest.fn().mockResolvedValue(null),
+            cacheResponse: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compile();
+
+    orchestrator = module.get(AuthOrchestrator);
+    metricsService = module.get(AuthMetricsService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ─── Success paths ───────────────────────────────────────────────────────
+
+  describe('successful auth — new user', () => {
+    it('records success_new_user outcome', async () => {
+      userService.findOrCreateUser.mockResolvedValue({
+        user: makeUser(),
+        isNewUser: true,
+      });
+      walletOrchestrator.getWalletByUser.mockResolvedValue(null);
+      walletOrchestrator.createWallet.mockResolvedValue({
+        wallet: makeWallet(),
+        privateKey: 'secret',
+        isNewWallet: true,
+      });
+
+      await orchestrator.handleAuthentication({ authId: 'auth-abc' });
+
+      const snap = metricsService.getSnapshot();
+      expect(snap.totalAttempts).toBe(1);
+      expect(snap.outcomes.success_new_user).toBe(1);
+      expect(snap.outcomes.success_returning_user).toBe(0);
+    });
+
+    it('records a positive latency sample', async () => {
+      userService.findOrCreateUser.mockResolvedValue({
+        user: makeUser(),
+        isNewUser: true,
+      });
+      walletOrchestrator.getWalletByUser.mockResolvedValue(null);
+      walletOrchestrator.createWallet.mockResolvedValue({
+        wallet: makeWallet(),
+        privateKey: 'secret',
+        isNewWallet: true,
+      });
+
+      await orchestrator.handleAuthentication({ authId: 'auth-abc' });
+
+      const snap = metricsService.getSnapshot();
+      expect(snap.averageLatencyMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('successful auth — returning user', () => {
+    it('records success_returning_user outcome', async () => {
+      userService.findOrCreateUser.mockResolvedValue({
+        user: makeUser(),
+        isNewUser: false,
+      });
+      walletOrchestrator.getWalletByUser.mockResolvedValue(makeWallet());
+
+      await orchestrator.handleAuthentication({ authId: 'auth-abc' });
+
+      const snap = metricsService.getSnapshot();
+      expect(snap.outcomes.success_returning_user).toBe(1);
+      expect(snap.outcomes.success_new_user).toBe(0);
+    });
+  });
+
+  // ─── Failure paths ───────────────────────────────────────────────────────
+
+  describe('invalid payload', () => {
+    it('records failure_invalid_payload when authId is missing', async () => {
+      await expect(
+        orchestrator.handleAuthentication({ authId: '' } as any),
+      ).rejects.toThrow(BadRequestException);
+
+      const snap = metricsService.getSnapshot();
+      expect(snap.outcomes.failure_invalid_payload).toBe(1);
+      expect(snap.totalAttempts).toBe(1);
+    });
+  });
+
+  describe('inactive user', () => {
+    it('records failure_user_inactive for suspended accounts', async () => {
+      userService.findOrCreateUser.mockResolvedValue({
+        user: makeUser({ status: 'SUSPENDED' }),
+        isNewUser: false,
+      });
+
+      await expect(
+        orchestrator.handleAuthentication({ authId: 'auth-abc' }),
+      ).rejects.toThrow(ForbiddenException);
+
+      const snap = metricsService.getSnapshot();
+      expect(snap.outcomes.failure_user_inactive).toBe(1);
+    });
+  });
+
+  describe('wallet creation error', () => {
+    it('records failure_wallet_error when wallet creation fails', async () => {
+      userService.findOrCreateUser.mockResolvedValue({
+        user: makeUser(),
+        isNewUser: true,
+      });
+      walletOrchestrator.getWalletByUser.mockResolvedValue(null);
+      walletOrchestrator.createWallet.mockRejectedValue(
+        new Error('Stellar unavailable'),
+      );
+
+      await expect(
+        orchestrator.handleAuthentication({ authId: 'auth-abc' }),
+      ).rejects.toThrow();
+
+      const snap = metricsService.getSnapshot();
+      expect(snap.outcomes.failure_wallet_error).toBe(1);
+    });
+  });
+
+  describe('unknown error', () => {
+    it('records failure_unknown for generic DB errors', async () => {
+      userService.findOrCreateUser.mockRejectedValue(new Error('DB down'));
+
+      await expect(
+        orchestrator.handleAuthentication({ authId: 'auth-abc' }),
+      ).rejects.toThrow('Authentication failed: DB down');
+
+      const snap = metricsService.getSnapshot();
+      expect(snap.outcomes.failure_unknown).toBe(1);
+    });
+  });
+
+  // ─── Accumulation across multiple calls ─────────────────────────────────
+
+  describe('accumulation', () => {
+    it('sums correctly across multiple successful calls', async () => {
+      const successSetup = () => {
+        userService.findOrCreateUser.mockResolvedValue({
+          user: makeUser(),
+          isNewUser: false,
+        });
+        walletOrchestrator.getWalletByUser.mockResolvedValue(makeWallet());
+      };
+
+      successSetup();
+      await orchestrator.handleAuthentication({ authId: 'auth-abc' });
+      successSetup();
+      await orchestrator.handleAuthentication({ authId: 'auth-abc' });
+      successSetup();
+      await orchestrator.handleAuthentication({ authId: 'auth-abc' });
+
+      const snap = metricsService.getSnapshot();
+      expect(snap.totalAttempts).toBe(3);
+      expect(snap.outcomes.success_returning_user).toBe(3);
+    });
+  });
+
+  // ─── Idempotency replays ─────────────────────────────────────────────────
+
+  describe('idempotency replay', () => {
+    it('does NOT double-count a replayed request', async () => {
+      // Simulate a cache hit from IdempotencyService
+      const idempotencyService = orchestrator['idempotencyService'];
+      (idempotencyService.getCachedResponse as jest.Mock).mockResolvedValue({
+        user: { id: 'u', authId: 'a', status: 'ACTIVE', authProvider: 'G', lastLoginAt: NOW },
+        wallet: { id: 'w', publicKey: 'pk', network: WalletNetwork.TESTNET, status: 'ACTIVE', createdAt: NOW },
+        isNewUser: false,
+        isNewWallet: false,
+      });
+
+      await orchestrator.handleAuthentication({
+        authId: 'auth-abc',
+        idempotencyKey: 'idem-key-123',
+      });
+
+      // totalAttempts should remain 0 because the result was served from cache
+      const snap = metricsService.getSnapshot();
+      expect(snap.totalAttempts).toBe(0);
+    });
+  });
+});

--- a/src/auth/auth-metrics.service.spec.ts
+++ b/src/auth/auth-metrics.service.spec.ts
@@ -1,0 +1,165 @@
+import { AuthMetricsService, AuthOutcome } from './auth-metrics.service';
+
+describe('AuthMetricsService', () => {
+  let service: AuthMetricsService;
+
+  beforeEach(() => {
+    service = new AuthMetricsService();
+  });
+
+  describe('initial state', () => {
+    it('returns zero counters on a fresh instance', () => {
+      const snap = service.getSnapshot();
+      expect(snap.totalAttempts).toBe(0);
+      expect(snap.rateLimitHits).toBe(0);
+      expect(snap.averageLatencyMs).toBe(0);
+      expect(snap.p95LatencyMs).toBe(0);
+    });
+
+    it('all outcome buckets start at 0', () => {
+      const { outcomes } = service.getSnapshot();
+      for (const val of Object.values(outcomes)) {
+        expect(val).toBe(0);
+      }
+    });
+
+    it('lastResetAt is a recent Date', () => {
+      const before = Date.now();
+      const svc = new AuthMetricsService();
+      const after = Date.now();
+      const snap = svc.getSnapshot();
+      expect(snap.lastResetAt.getTime()).toBeGreaterThanOrEqual(before);
+      expect(snap.lastResetAt.getTime()).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('recordAttempt()', () => {
+    it('increments totalAttempts', () => {
+      service.recordAttempt('success_returning_user', 50);
+      expect(service.getSnapshot().totalAttempts).toBe(1);
+    });
+
+    it('increments the correct outcome bucket', () => {
+      service.recordAttempt('success_new_user', 100);
+      service.recordAttempt('success_new_user', 120);
+      service.recordAttempt('failure_unknown', 10);
+
+      const { outcomes } = service.getSnapshot();
+      expect(outcomes.success_new_user).toBe(2);
+      expect(outcomes.failure_unknown).toBe(1);
+      expect(outcomes.success_returning_user).toBe(0);
+    });
+
+    it('does not cross-contaminate outcome buckets', () => {
+      const allOutcomes: AuthOutcome[] = [
+        'success_new_user',
+        'success_returning_user',
+        'failure_invalid_payload',
+        'failure_user_inactive',
+        'failure_wallet_error',
+        'failure_unknown',
+      ];
+
+      allOutcomes.forEach((o, i) => service.recordAttempt(o, i * 10));
+
+      const { outcomes } = service.getSnapshot();
+      allOutcomes.forEach((o) => expect(outcomes[o]).toBe(1));
+    });
+
+    it('computes correct average latency from a single sample', () => {
+      service.recordAttempt('success_returning_user', 80);
+      expect(service.getSnapshot().averageLatencyMs).toBe(80);
+    });
+
+    it('computes correct average latency from multiple samples', () => {
+      service.recordAttempt('success_returning_user', 100);
+      service.recordAttempt('success_returning_user', 200);
+      service.recordAttempt('success_returning_user', 300);
+      expect(service.getSnapshot().averageLatencyMs).toBe(200);
+    });
+
+    it('computes p95 latency correctly with enough samples', () => {
+      // 20 samples: 1..20ms — p95 should be ~19ms
+      for (let i = 1; i <= 20; i++) {
+        service.recordAttempt('success_returning_user', i);
+      }
+      // sorted = [1..20], p95 index = ceil(0.95*20)-1 = 19-1 = 18 → value=19
+      expect(service.getSnapshot().p95LatencyMs).toBe(19);
+    });
+  });
+
+  describe('recordRateLimitHit()', () => {
+    it('increments rateLimitHits', () => {
+      service.recordRateLimitHit();
+      service.recordRateLimitHit();
+      expect(service.getSnapshot().rateLimitHits).toBe(2);
+    });
+
+    it('does not affect totalAttempts', () => {
+      service.recordRateLimitHit();
+      expect(service.getSnapshot().totalAttempts).toBe(0);
+    });
+  });
+
+  describe('reset()', () => {
+    it('zeros all counters', () => {
+      service.recordAttempt('success_new_user', 100);
+      service.recordAttempt('failure_unknown', 50);
+      service.recordRateLimitHit();
+      service.reset();
+
+      const snap = service.getSnapshot();
+      expect(snap.totalAttempts).toBe(0);
+      expect(snap.rateLimitHits).toBe(0);
+      expect(snap.averageLatencyMs).toBe(0);
+      expect(snap.p95LatencyMs).toBe(0);
+      for (const val of Object.values(snap.outcomes)) {
+        expect(val).toBe(0);
+      }
+    });
+
+    it('updates lastResetAt', async () => {
+      const before = service.getSnapshot().lastResetAt;
+      // Small delay to guarantee timestamp advances
+      await new Promise((r) => setTimeout(r, 2));
+      service.reset();
+      const after = service.getSnapshot().lastResetAt;
+      expect(after.getTime()).toBeGreaterThan(before.getTime());
+    });
+
+    it('allows new recordings after reset', () => {
+      service.recordAttempt('success_new_user', 100);
+      service.reset();
+      service.recordAttempt('success_returning_user', 50);
+      const snap = service.getSnapshot();
+      expect(snap.totalAttempts).toBe(1);
+      expect(snap.outcomes.success_returning_user).toBe(1);
+      expect(snap.outcomes.success_new_user).toBe(0);
+    });
+  });
+
+  describe('ring-buffer behaviour', () => {
+    it('handles more samples than the ring-buffer capacity gracefully', () => {
+      // Fill well beyond MAX_LATENCY_SAMPLES (1000) — just verify it doesn't
+      // throw and produces a sensible average.
+      const count = 1100;
+      for (let i = 0; i < count; i++) {
+        service.recordAttempt('success_returning_user', 100);
+      }
+      const snap = service.getSnapshot();
+      expect(snap.totalAttempts).toBe(count);
+      expect(snap.averageLatencyMs).toBe(100);
+    });
+  });
+
+  describe('getSnapshot() immutability', () => {
+    it('returns a copy of the outcomes object, not a live reference', () => {
+      const snap1 = service.getSnapshot();
+      service.recordAttempt('success_new_user', 10);
+      const snap2 = service.getSnapshot();
+      // snap1 should not reflect the new recording
+      expect(snap1.outcomes.success_new_user).toBe(0);
+      expect(snap2.outcomes.success_new_user).toBe(1);
+    });
+  });
+});

--- a/src/auth/auth-metrics.service.ts
+++ b/src/auth/auth-metrics.service.ts
@@ -1,0 +1,150 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * Outcome labels for an authentication attempt.
+ */
+export type AuthOutcome =
+  | 'success_new_user'
+  | 'success_returning_user'
+  | 'failure_invalid_payload'
+  | 'failure_user_inactive'
+  | 'failure_wallet_error'
+  | 'failure_unknown';
+
+/**
+ * Snapshot of counters exposed by AuthMetricsService.
+ */
+export interface AuthMetricsSnapshot {
+  totalAttempts: number;
+  outcomes: Record<AuthOutcome, number>;
+  rateLimitHits: number;
+  /** Rolling average latency in ms across the last window of recorded calls */
+  averageLatencyMs: number;
+  /** P95 latency in ms (approximated from recorded samples) */
+  p95LatencyMs: number;
+  /** Timestamp when metrics counters were last reset */
+  lastResetAt: Date;
+}
+
+/**
+ * In-process metrics store for the auth & session subsystem.
+ *
+ * Design notes
+ * ─────────────
+ * • All state is in-memory. For multi-instance deployments the expectation is
+ *   that consumers aggregate across replicas (e.g. via a scrape endpoint or
+ *   a Prometheus push-gateway). No external dependency is added here so the
+ *   feature works in any environment without extra infrastructure.
+ * • Counters are plain numbers — no atomics needed because Node.js is
+ *   single-threaded within a process.
+ * • Latency samples are kept in a bounded ring-buffer (default 1 000 entries)
+ *   to avoid unbounded memory growth.
+ */
+@Injectable()
+export class AuthMetricsService {
+  private readonly logger = new Logger(AuthMetricsService.name);
+
+  /** Maximum number of latency samples retained in the ring-buffer. */
+  private static readonly MAX_LATENCY_SAMPLES = 1_000;
+
+  private totalAttempts = 0;
+  private rateLimitHits = 0;
+  private readonly outcomeCounts: Record<AuthOutcome, number> = {
+    success_new_user: 0,
+    success_returning_user: 0,
+    failure_invalid_payload: 0,
+    failure_user_inactive: 0,
+    failure_wallet_error: 0,
+    failure_unknown: 0,
+  };
+
+  /** Ring-buffer of recorded latency samples (ms). */
+  private readonly latencySamples: number[] = [];
+  private latencyIndex = 0; // next write position in ring-buffer
+
+  private lastResetAt: Date = new Date();
+
+  // ─── Public instrumentation API ──────────────────────────────────────────
+
+  /**
+   * Records the result of one authentication flow execution.
+   *
+   * @param outcome  Categorised result label.
+   * @param latencyMs  Wall-clock time for the full orchestration call.
+   */
+  recordAttempt(outcome: AuthOutcome, latencyMs: number): void {
+    this.totalAttempts++;
+    this.outcomeCounts[outcome]++;
+    this.recordLatency(latencyMs);
+
+    this.logger.debug(
+      `auth.attempt outcome=${outcome} latency=${latencyMs}ms total=${this.totalAttempts}`,
+    );
+  }
+
+  /**
+   * Records a rate-limit rejection on the auth endpoint.
+   */
+  recordRateLimitHit(): void {
+    this.rateLimitHits++;
+    this.logger.debug(
+      `auth.rate_limit_hit total_hits=${this.rateLimitHits}`,
+    );
+  }
+
+  /**
+   * Returns a point-in-time snapshot of all counters.
+   */
+  getSnapshot(): AuthMetricsSnapshot {
+    return {
+      totalAttempts: this.totalAttempts,
+      outcomes: { ...this.outcomeCounts },
+      rateLimitHits: this.rateLimitHits,
+      averageLatencyMs: this.computeAverage(),
+      p95LatencyMs: this.computePercentile(95),
+      lastResetAt: this.lastResetAt,
+    };
+  }
+
+  /**
+   * Resets all counters and samples. Useful for tests and scheduled resets.
+   */
+  reset(): void {
+    this.totalAttempts = 0;
+    this.rateLimitHits = 0;
+    for (const key of Object.keys(this.outcomeCounts) as AuthOutcome[]) {
+      this.outcomeCounts[key] = 0;
+    }
+    this.latencySamples.length = 0;
+    this.latencyIndex = 0;
+    this.lastResetAt = new Date();
+    this.logger.log('Auth metrics counters reset');
+  }
+
+  // ─── Private helpers ──────────────────────────────────────────────────────
+
+  private recordLatency(ms: number): void {
+    if (this.latencySamples.length < AuthMetricsService.MAX_LATENCY_SAMPLES) {
+      this.latencySamples.push(ms);
+    } else {
+      // Overwrite oldest entry
+      this.latencySamples[
+        this.latencyIndex % AuthMetricsService.MAX_LATENCY_SAMPLES
+      ] = ms;
+    }
+    this.latencyIndex++;
+  }
+
+  private computeAverage(): number {
+    if (this.latencySamples.length === 0) return 0;
+    const sum = this.latencySamples.reduce((a, b) => a + b, 0);
+    return Math.round(sum / this.latencySamples.length);
+  }
+
+  private computePercentile(pct: number): number {
+    if (this.latencySamples.length === 0) return 0;
+    const sorted = [...this.latencySamples].sort((a, b) => a - b);
+    const idx = Math.ceil((pct / 100) * sorted.length) - 1;
+    return sorted[Math.max(0, idx)];
+  }
+}

--- a/src/auth/auth-orchestrator.integration.spec.ts
+++ b/src/auth/auth-orchestrator.integration.spec.ts
@@ -16,6 +16,7 @@ import { IdempotentUserService } from '../users/idempotent-user.service';
 import { WalletCreationOrchestrator } from '../wallets/wallet-creation-orchestrator.service';
 import { WalletNetwork, WalletStatus } from '../wallets/domain/wallet.model';
 import { IdempotencyService } from '../common/idempotency/idempotency.service';
+import { AuthMetricsService } from './auth-metrics.service';
 
 // ---------------------------------------------------------------------------
 // Shared fixtures
@@ -89,6 +90,15 @@ describe('AuthOrchestrator (integration harness)', () => {
           useValue: {
             getCachedResponse: jest.fn().mockResolvedValue(null),
             cacheResponse: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: AuthMetricsService,
+          useValue: {
+            recordAttempt: jest.fn(),
+            recordRateLimitHit: jest.fn(),
+            getSnapshot: jest.fn(),
+            reset: jest.fn(),
           },
         },
       ],

--- a/src/auth/auth-orchestrator.service.spec.ts
+++ b/src/auth/auth-orchestrator.service.spec.ts
@@ -4,6 +4,7 @@ import { AuthOrchestrator, AuthPayloadValidator } from './auth-orchestrator.serv
 import { IdempotentUserService } from '../users/idempotent-user.service';
 import { WalletCreationOrchestrator } from '../wallets/wallet-creation-orchestrator.service';
 import { IdempotencyService } from '../common/idempotency/idempotency.service';
+import { AuthMetricsService } from './auth-metrics.service';
 import { WalletNetwork } from '../wallets/domain/wallet.model';
 
 describe('AuthPayloadValidator', () => {
@@ -175,6 +176,13 @@ describe('AuthOrchestrator', () => {
     cacheResponse: jest.fn(),
   };
 
+  const mockAuthMetrics = {
+    recordAttempt: jest.fn(),
+    recordRateLimitHit: jest.fn(),
+    getSnapshot: jest.fn(),
+    reset: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -190,6 +198,10 @@ describe('AuthOrchestrator', () => {
         {
           provide: IdempotencyService,
           useValue: mockIdempotencyService,
+        },
+        {
+          provide: AuthMetricsService,
+          useValue: mockAuthMetrics,
         },
       ],
     }).compile();

--- a/src/auth/auth-orchestrator.service.ts
+++ b/src/auth/auth-orchestrator.service.ts
@@ -17,6 +17,7 @@ import {
 } from '../wallets/wallet-creation-orchestrator.service';
 import { WalletNetwork } from '../wallets/domain/wallet.model';
 import { IdempotencyService } from '../common/idempotency/idempotency.service';
+import { AuthMetricsService } from './auth-metrics.service';
 
 export interface AuthenticationRequest {
   authId: string;
@@ -160,6 +161,7 @@ export class AuthOrchestrator {
     private readonly idempotentUserService: IdempotentUserService,
     private readonly walletCreationOrchestrator: WalletCreationOrchestrator,
     private readonly idempotencyService: IdempotencyService,
+    private readonly authMetrics: AuthMetricsService,
   ) {}
 
   /**
@@ -173,7 +175,13 @@ export class AuthOrchestrator {
     const startTime = Date.now();
 
     // Validate auth provider payload shape before processing
-    AuthPayloadValidator.validate(request);
+    try {
+      AuthPayloadValidator.validate(request);
+    } catch (validationError) {
+      const latency = Date.now() - startTime;
+      this.authMetrics.recordAttempt('failure_invalid_payload', latency);
+      throw validationError;
+    }
 
     const network = request.network || WalletNetwork.TESTNET;
 
@@ -191,6 +199,7 @@ export class AuthOrchestrator {
           this.logger.log(
             `Returning cached authentication result for idempotency key: ${request.idempotencyKey}`,
           );
+          // Replayed responses are not double-counted as new attempts
           return {
             ...cachedResponse,
             _idempotencyReplayed: true,
@@ -202,20 +211,39 @@ export class AuthOrchestrator {
       const userResult = await this.findOrCreateUser(request);
 
       // Step 1.5: Check if user is active
-      this.validateUserStatus(userResult.user);
+      try {
+        this.validateUserStatus(userResult.user);
+      } catch (statusError) {
+        const latency = Date.now() - startTime;
+        this.authMetrics.recordAttempt('failure_user_inactive', latency);
+        throw statusError;
+      }
 
       // Step 2: Ensure user has a wallet (idempotent)
-      const walletResult = await this.ensureUserHasWallet(
-        userResult.user.id,
-        network,
-        userResult.isNewUser,
-      );
+      let walletResult: Awaited<ReturnType<typeof this.ensureUserHasWallet>>;
+      try {
+        walletResult = await this.ensureUserHasWallet(
+          userResult.user.id,
+          network,
+          userResult.isNewUser,
+        );
+      } catch (walletError) {
+        const latency = Date.now() - startTime;
+        this.authMetrics.recordAttempt('failure_wallet_error', latency);
+        throw walletError;
+      }
 
       const duration = Date.now() - startTime;
       this.logger.log(
         `Authentication orchestration completed in ${duration}ms for authId: ${request.authId} ` +
           `(newUser: ${userResult.isNewUser}, newWallet: ${walletResult.isNewWallet})`,
       );
+
+      // Record success metric
+      const outcome = userResult.isNewUser
+        ? 'success_new_user'
+        : 'success_returning_user';
+      this.authMetrics.recordAttempt(outcome, duration);
 
       const result: AuthenticationResultWithMetadata = {
         user: {
@@ -262,6 +290,9 @@ export class AuthOrchestrator {
       if (error instanceof HttpException) {
         throw error;
       }
+      // Only record 'failure_unknown' if not already classified above
+      const latency = Date.now() - startTime;
+      this.authMetrics.recordAttempt('failure_unknown', latency);
       throw new Error(`Authentication failed: ${error.message}`);
     }
   }

--- a/src/auth/auth-rate-limit.guard.spec.ts
+++ b/src/auth/auth-rate-limit.guard.spec.ts
@@ -2,14 +2,23 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { HttpStatus, HttpException } from '@nestjs/common';
 import { AuthRateLimitGuard } from './auth-rate-limit.guard';
 import { AuthRateLimitService } from './auth-rate-limit.service';
+import { AuthMetricsService } from './auth-metrics.service';
 
 describe('AuthRateLimitGuard', () => {
   let guard: AuthRateLimitGuard;
   let authRateLimitService: jest.Mocked<AuthRateLimitService>;
+  let authMetrics: jest.Mocked<AuthMetricsService>;
 
   const mockAuthRateLimitService = {
     checkRateLimit: jest.fn(),
     getConfig: jest.fn(),
+  };
+
+  const mockAuthMetrics = {
+    recordAttempt: jest.fn(),
+    recordRateLimitHit: jest.fn(),
+    getSnapshot: jest.fn(),
+    reset: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -20,11 +29,16 @@ describe('AuthRateLimitGuard', () => {
           provide: AuthRateLimitService,
           useValue: mockAuthRateLimitService,
         },
+        {
+          provide: AuthMetricsService,
+          useValue: mockAuthMetrics,
+        },
       ],
     }).compile();
 
     guard = module.get<AuthRateLimitGuard>(AuthRateLimitGuard);
     authRateLimitService = module.get(AuthRateLimitService);
+    authMetrics = module.get(AuthMetricsService);
 
     jest.clearAllMocks();
   });
@@ -187,6 +201,63 @@ describe('AuthRateLimitGuard', () => {
         expect(error).toBeInstanceOf(HttpException);
         expect(error.getStatus()).toBe(HttpStatus.TOO_MANY_REQUESTS);
       }
+    });
+
+    it('should call authMetrics.recordRateLimitHit() when rate limit is exceeded', async () => {
+      const mockRequest = {
+        headers: {},
+        connection: { remoteAddress: '10.0.0.1' },
+      };
+      const mockResponse = { setHeader: jest.fn() };
+      const mockExecutionContext = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getRequest: jest.fn().mockReturnValue(mockRequest),
+          getResponse: jest.fn().mockReturnValue(mockResponse),
+        }),
+      } as any;
+
+      mockAuthRateLimitService.checkRateLimit.mockResolvedValue({
+        allowed: false,
+        remaining: 0,
+        resetTime: new Date(Date.now() + 30000),
+        limit: 10,
+        retryAfterSeconds: 30,
+      });
+      mockAuthRateLimitService.getConfig.mockReturnValue({
+        maxRequests: 10,
+        windowMs: 60000,
+      });
+
+      await expect(guard.canActivate(mockExecutionContext)).rejects.toThrow(
+        HttpException,
+      );
+
+      expect(mockAuthMetrics.recordRateLimitHit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT call authMetrics.recordRateLimitHit() when request is allowed', async () => {
+      const mockRequest = {
+        headers: {},
+        connection: { remoteAddress: '10.0.0.2' },
+      };
+      const mockResponse = { setHeader: jest.fn() };
+      const mockExecutionContext = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getRequest: jest.fn().mockReturnValue(mockRequest),
+          getResponse: jest.fn().mockReturnValue(mockResponse),
+        }),
+      } as any;
+
+      mockAuthRateLimitService.checkRateLimit.mockResolvedValue({
+        allowed: true,
+        remaining: 5,
+        resetTime: new Date(),
+        limit: 10,
+      });
+
+      await guard.canActivate(mockExecutionContext);
+
+      expect(mockAuthMetrics.recordRateLimitHit).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/auth/auth-rate-limit.guard.ts
+++ b/src/auth/auth-rate-limit.guard.ts
@@ -7,12 +7,16 @@ import {
   Logger,
 } from '@nestjs/common';
 import { AuthRateLimitService } from './auth-rate-limit.service';
+import { AuthMetricsService } from './auth-metrics.service';
 
 @Injectable()
 export class AuthRateLimitGuard implements CanActivate {
   private readonly logger = new Logger(AuthRateLimitGuard.name);
 
-  constructor(private readonly authRateLimitService: AuthRateLimitService) {}
+  constructor(
+    private readonly authRateLimitService: AuthRateLimitService,
+    private readonly authMetrics: AuthMetricsService,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
@@ -36,6 +40,9 @@ export class AuthRateLimitGuard implements CanActivate {
       this.logger.warn(
         `Auth rate limit exceeded for IP ${ipAddress}: ${result.limit} requests per ${this.authRateLimitService.getConfig().windowMs}ms`,
       );
+
+      // Record the rate-limit hit in metrics
+      this.authMetrics.recordRateLimitHit();
 
       // Set Retry-After header
       if (result.retryAfterSeconds) {
@@ -70,9 +77,9 @@ export class AuthRateLimitGuard implements CanActivate {
 
     // Fall back to request connection address
     return (
-      request.connection.remoteAddress ||
-      request.socket.remoteAddress ||
-      request.connection.socket?.remoteAddress ||
+      request.connection?.remoteAddress ||
+      request.socket?.remoteAddress ||
+      request.connection?.socket?.remoteAddress ||
       'unknown'
     );
   }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,24 +3,28 @@ import { AuthOrchestrator } from './auth-orchestrator.service';
 import { AuthOrchestratorController } from './auth-orchestrator.controller';
 import { AuthRateLimitService } from './auth-rate-limit.service';
 import { AuthRateLimitGuard } from './auth-rate-limit.guard';
+import { AuthMetricsService } from './auth-metrics.service';
+import { AuthMetricsController } from './auth-metrics.controller';
 import { IdempotentUserModule } from '../users/idempotent-user.module';
 import { WalletsModule } from '../wallets/wallets.module';
 import { IdempotencyService } from '../common/idempotency/idempotency.service';
 
 @Module({
   imports: [IdempotentUserModule, WalletsModule],
-  controllers: [AuthOrchestratorController],
+  controllers: [AuthOrchestratorController, AuthMetricsController],
   providers: [
     AuthOrchestrator,
     IdempotencyService,
     AuthRateLimitService,
     AuthRateLimitGuard,
+    AuthMetricsService,
   ],
   exports: [
     AuthOrchestrator,
     IdempotencyService,
     AuthRateLimitService,
     AuthRateLimitGuard,
+    AuthMetricsService,
   ],
 })
 export class AuthModule {}

--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for the startup environment validator.
+ *
+ * NODE_ENV=test is set by Jest, so validateEnv() throws an Error instead of
+ * calling process.exit(). This lets us assert on the error message.
+ */
+import { validateEnv, ValidatedEnv } from './env.validation';
+
+// ─── Minimal valid env ────────────────────────────────────────────────────────
+
+const VALID_ENV: NodeJS.ProcessEnv = {
+  NODE_ENV: 'test',
+  DATABASE_URL: 'postgresql://user:pass@localhost:5432/mux_test',
+  WALLET_ENCRYPTION_KEY: 'a'.repeat(32), // exactly 32 chars
+  STELLAR_HORIZON_URL: 'https://horizon-testnet.stellar.org',
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function env(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return { ...VALID_ENV, ...overrides };
+}
+
+function expectError(input: NodeJS.ProcessEnv, fragment: string) {
+  expect(() => validateEnv(input)).toThrow(fragment);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('validateEnv()', () => {
+  describe('DATABASE_URL', () => {
+    it('accepts a valid postgresql:// URL', () => {
+      expect(() => validateEnv(env())).not.toThrow();
+    });
+
+    it('accepts a postgres:// URL', () => {
+      expect(() =>
+        validateEnv(env({ DATABASE_URL: 'postgres://u:p@localhost/db' })),
+      ).not.toThrow();
+    });
+
+    it('rejects when absent', () => {
+      expectError(env({ DATABASE_URL: undefined }), 'DATABASE_URL is required');
+    });
+
+    it('rejects empty string', () => {
+      expectError(env({ DATABASE_URL: '' }), 'DATABASE_URL is required');
+    });
+
+    it('rejects non-postgres scheme', () => {
+      expectError(
+        env({ DATABASE_URL: 'mysql://user:pass@localhost/db' }),
+        'DATABASE_URL must be a PostgreSQL connection string',
+      );
+    });
+  });
+
+  describe('WALLET_ENCRYPTION_KEY', () => {
+    it('accepts a key of exactly 32 characters', () => {
+      expect(() => validateEnv(env({ WALLET_ENCRYPTION_KEY: 'x'.repeat(32) }))).not.toThrow();
+    });
+
+    it('accepts a key longer than 32 characters', () => {
+      expect(() => validateEnv(env({ WALLET_ENCRYPTION_KEY: 'x'.repeat(64) }))).not.toThrow();
+    });
+
+    it('rejects when absent', () => {
+      expectError(env({ WALLET_ENCRYPTION_KEY: undefined }), 'WALLET_ENCRYPTION_KEY is required');
+    });
+
+    it('rejects a key shorter than 32 characters', () => {
+      expectError(
+        env({ WALLET_ENCRYPTION_KEY: 'short' }),
+        'WALLET_ENCRYPTION_KEY must be at least 32 characters',
+      );
+    });
+  });
+
+  describe('STELLAR_HORIZON_URL', () => {
+    it('accepts a valid https URL', () => {
+      expect(() => validateEnv(env())).not.toThrow();
+    });
+
+    it('accepts a valid http URL', () => {
+      expect(() =>
+        validateEnv(env({ STELLAR_HORIZON_URL: 'http://localhost:8000' })),
+      ).not.toThrow();
+    });
+
+    it('rejects when absent', () => {
+      expectError(env({ STELLAR_HORIZON_URL: undefined }), 'STELLAR_HORIZON_URL is required');
+    });
+
+    it('rejects a non-URL string', () => {
+      expectError(
+        env({ STELLAR_HORIZON_URL: 'not-a-url' }),
+        'STELLAR_HORIZON_URL must be a valid URL',
+      );
+    });
+
+    it('rejects ftp:// scheme', () => {
+      expectError(
+        env({ STELLAR_HORIZON_URL: 'ftp://example.com' }),
+        'STELLAR_HORIZON_URL must use http or https protocol',
+      );
+    });
+  });
+
+  describe('PORT', () => {
+    it('defaults to 3000 when not set', () => {
+      const result = validateEnv(env());
+      expect(result.PORT).toBe(3000);
+    });
+
+    it('accepts a valid port number', () => {
+      const result = validateEnv(env({ PORT: '8080' }));
+      expect(result.PORT).toBe(8080);
+    });
+
+    it('rejects port 0', () => {
+      expectError(env({ PORT: '0' }), 'PORT must be >= 1');
+    });
+
+    it('rejects port > 65535', () => {
+      expectError(env({ PORT: '65536' }), 'PORT must be <= 65535');
+    });
+
+    it('rejects a non-integer string', () => {
+      expectError(env({ PORT: 'abc' }), 'PORT must be an integer');
+    });
+  });
+
+  describe('AUTH_RATE_LIMIT_MAX', () => {
+    it('defaults to 10', () => {
+      const result = validateEnv(env());
+      expect(result.AUTH_RATE_LIMIT_MAX).toBe(10);
+    });
+
+    it('accepts a custom value', () => {
+      const result = validateEnv(env({ AUTH_RATE_LIMIT_MAX: '20' }));
+      expect(result.AUTH_RATE_LIMIT_MAX).toBe(20);
+    });
+
+    it('rejects 0', () => {
+      expectError(env({ AUTH_RATE_LIMIT_MAX: '0' }), 'AUTH_RATE_LIMIT_MAX must be >= 1');
+    });
+  });
+
+  describe('AUTH_RATE_LIMIT_WINDOW_MS', () => {
+    it('defaults to 60000', () => {
+      const result = validateEnv(env());
+      expect(result.AUTH_RATE_LIMIT_WINDOW_MS).toBe(60_000);
+    });
+
+    it('rejects a value below 1000ms', () => {
+      expectError(
+        env({ AUTH_RATE_LIMIT_WINDOW_MS: '500' }),
+        'AUTH_RATE_LIMIT_WINDOW_MS must be >= 1000',
+      );
+    });
+  });
+
+  describe('WEBHOOK_MAX_RETRIES', () => {
+    it('defaults to 5', () => {
+      const result = validateEnv(env());
+      expect(result.WEBHOOK_MAX_RETRIES).toBe(5);
+    });
+
+    it('accepts 0 (disable retries)', () => {
+      const result = validateEnv(env({ WEBHOOK_MAX_RETRIES: '0' }));
+      expect(result.WEBHOOK_MAX_RETRIES).toBe(0);
+    });
+
+    it('rejects a value above 100', () => {
+      expectError(env({ WEBHOOK_MAX_RETRIES: '101' }), 'WEBHOOK_MAX_RETRIES must be <= 100');
+    });
+  });
+
+  describe('WEBHOOK_TIMEOUT_MS', () => {
+    it('defaults to 10000', () => {
+      const result = validateEnv(env());
+      expect(result.WEBHOOK_TIMEOUT_MS).toBe(10_000);
+    });
+
+    it('rejects values below 100ms', () => {
+      expectError(
+        env({ WEBHOOK_TIMEOUT_MS: '50' }),
+        'WEBHOOK_TIMEOUT_MS must be >= 100',
+      );
+    });
+  });
+
+  describe('multiple violations', () => {
+    it('reports all errors in a single throw', () => {
+      const badEnv = env({
+        DATABASE_URL: undefined,
+        WALLET_ENCRYPTION_KEY: undefined,
+        STELLAR_HORIZON_URL: undefined,
+      });
+
+      let message = '';
+      try {
+        validateEnv(badEnv);
+      } catch (e: any) {
+        message = e.message;
+      }
+
+      expect(message).toContain('DATABASE_URL');
+      expect(message).toContain('WALLET_ENCRYPTION_KEY');
+      expect(message).toContain('STELLAR_HORIZON_URL');
+      expect(message).toContain('3 environment variable problem(s)');
+    });
+  });
+
+  describe('return value', () => {
+    it('returns a fully-typed ValidatedEnv on success', () => {
+      const result: ValidatedEnv = validateEnv(
+        env({
+          PORT: '4000',
+          AUTH_RATE_LIMIT_MAX: '25',
+          API_KEY_ROTATION_GRACE_SECONDS: '7200',
+        }),
+      );
+
+      expect(result.PORT).toBe(4000);
+      expect(result.AUTH_RATE_LIMIT_MAX).toBe(25);
+      expect(result.API_KEY_ROTATION_GRACE_SECONDS).toBe(7200);
+      expect(result.DATABASE_URL).toBe(VALID_ENV.DATABASE_URL);
+      expect(result.WALLET_ENCRYPTION_KEY).toBe(VALID_ENV.WALLET_ENCRYPTION_KEY);
+      expect(result.STELLAR_HORIZON_URL).toBe(VALID_ENV.STELLAR_HORIZON_URL);
+    });
+
+    it('fills in all defaults when only required fields are set', () => {
+      const result = validateEnv(env());
+      expect(result.PORT).toBe(3000);
+      expect(result.BALANCE_STALE_THRESHOLD_MS).toBe(300_000);
+      expect(result.WEBHOOK_MAX_RETRIES).toBe(5);
+      expect(result.WEBHOOK_RETRY_BACKOFF_MS).toBe(1_000);
+      expect(result.WEBHOOK_TIMEOUT_MS).toBe(10_000);
+      expect(result.WEBHOOK_MAX_CONSECUTIVE_FAILURES).toBe(10);
+      expect(result.AUTH_RATE_LIMIT_MAX).toBe(10);
+      expect(result.AUTH_RATE_LIMIT_WINDOW_MS).toBe(60_000);
+      expect(result.RATE_LIMIT_WINDOW_MS).toBe(60_000);
+      expect(result.RATE_LIMIT_MAX_REQUESTS).toBe(100);
+      expect(result.RATE_LIMIT_SENSITIVE_WINDOW_MS).toBe(60_000);
+      expect(result.RATE_LIMIT_SENSITIVE_MAX_REQUESTS).toBe(10);
+      expect(result.API_KEY_ROTATION_GRACE_SECONDS).toBe(3_600);
+    });
+  });
+});

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -1,0 +1,297 @@
+/**
+ * Startup environment validation
+ *
+ * Validates all required and optional environment variables before the NestJS
+ * application starts. Any missing required variable or out-of-range value
+ * causes an immediate process exit with a human-readable error listing every
+ * problem found.
+ *
+ * Usage — called once in main.ts before NestFactory.create():
+ *
+ *   import { validateEnv } from './config/env.validation';
+ *   validateEnv(process.env);
+ */
+
+export interface EnvViolation {
+  variable: string;
+  message: string;
+}
+
+export interface ValidatedEnv {
+  DATABASE_URL: string;
+  PORT: number;
+  WALLET_ENCRYPTION_KEY: string;
+  STELLAR_HORIZON_URL: string;
+  BALANCE_STALE_THRESHOLD_MS: number;
+  WEBHOOK_MAX_RETRIES: number;
+  WEBHOOK_RETRY_BACKOFF_MS: number;
+  WEBHOOK_TIMEOUT_MS: number;
+  WEBHOOK_MAX_CONSECUTIVE_FAILURES: number;
+  AUTH_RATE_LIMIT_MAX: number;
+  AUTH_RATE_LIMIT_WINDOW_MS: number;
+  RATE_LIMIT_WINDOW_MS: number;
+  RATE_LIMIT_MAX_REQUESTS: number;
+  RATE_LIMIT_SENSITIVE_WINDOW_MS: number;
+  RATE_LIMIT_SENSITIVE_MAX_REQUESTS: number;
+  API_KEY_ROTATION_GRACE_SECONDS: number;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function requireString(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  violations: EnvViolation[],
+): string {
+  const val = env[key];
+  if (!val || val.trim().length === 0) {
+    violations.push({ variable: key, message: `${key} is required` });
+    return '';
+  }
+  return val.trim();
+}
+
+function optionalInt(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  defaultValue: number,
+  options: { min?: number; max?: number } = {},
+  violations: EnvViolation[],
+): number {
+  const raw = env[key];
+  if (raw === undefined || raw.trim() === '') {
+    return defaultValue;
+  }
+  const parsed = parseInt(raw, 10);
+  if (isNaN(parsed)) {
+    violations.push({
+      variable: key,
+      message: `${key} must be an integer (received "${raw}")`,
+    });
+    return defaultValue;
+  }
+  if (options.min !== undefined && parsed < options.min) {
+    violations.push({
+      variable: key,
+      message: `${key} must be >= ${options.min} (received ${parsed})`,
+    });
+  }
+  if (options.max !== undefined && parsed > options.max) {
+    violations.push({
+      variable: key,
+      message: `${key} must be <= ${options.max} (received ${parsed})`,
+    });
+  }
+  return parsed;
+}
+
+function requireUrl(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  violations: EnvViolation[],
+): string {
+  const val = requireString(env, key, violations);
+  if (!val) return '';
+  try {
+    const url = new URL(val);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      violations.push({
+        variable: key,
+        message: `${key} must use http or https protocol (received "${val}")`,
+      });
+    }
+  } catch {
+    violations.push({
+      variable: key,
+      message: `${key} must be a valid URL (received "${val}")`,
+    });
+  }
+  return val;
+}
+
+function requireDatabaseUrl(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  violations: EnvViolation[],
+): string {
+  const val = requireString(env, key, violations);
+  if (!val) return '';
+  // Accept postgresql:// or postgres:// schemes
+  if (!/^postgre?s:\/\//i.test(val)) {
+    violations.push({
+      variable: key,
+      message: `${key} must be a PostgreSQL connection string starting with postgresql:// or postgres:// (received scheme: "${val.split(':')[0]}")`,
+    });
+  }
+  return val;
+}
+
+function requireMinLength(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  minLength: number,
+  violations: EnvViolation[],
+): string {
+  const val = requireString(env, key, violations);
+  if (!val) return '';
+  if (val.length < minLength) {
+    violations.push({
+      variable: key,
+      message: `${key} must be at least ${minLength} characters long (got ${val.length})`,
+    });
+  }
+  return val;
+}
+
+// ─── Main validation function ─────────────────────────────────────────────────
+
+/**
+ * Validates the given environment object.
+ *
+ * @param env  Typically `process.env`.
+ * @returns A fully-typed, normalised env object on success.
+ * @throws  When running outside tests: exits the process with code 1.
+ *          When running inside Jest (NODE_ENV=test): throws an Error instead
+ *          so test assertions can catch it.
+ */
+export function validateEnv(env: NodeJS.ProcessEnv): ValidatedEnv {
+  const violations: EnvViolation[] = [];
+
+  // ── Required fields ───────────────────────────────────────────────────────
+  const DATABASE_URL = requireDatabaseUrl(env, 'DATABASE_URL', violations);
+  const WALLET_ENCRYPTION_KEY = requireMinLength(
+    env,
+    'WALLET_ENCRYPTION_KEY',
+    32,
+    violations,
+  );
+  const STELLAR_HORIZON_URL = requireUrl(
+    env,
+    'STELLAR_HORIZON_URL',
+    violations,
+  );
+
+  // ── Optional numeric fields ───────────────────────────────────────────────
+  const PORT = optionalInt(env, 'PORT', 3000, { min: 1, max: 65535 }, violations);
+  const BALANCE_STALE_THRESHOLD_MS = optionalInt(
+    env,
+    'BALANCE_STALE_THRESHOLD_MS',
+    300_000,
+    { min: 0 },
+    violations,
+  );
+  const WEBHOOK_MAX_RETRIES = optionalInt(
+    env,
+    'WEBHOOK_MAX_RETRIES',
+    5,
+    { min: 0, max: 100 },
+    violations,
+  );
+  const WEBHOOK_RETRY_BACKOFF_MS = optionalInt(
+    env,
+    'WEBHOOK_RETRY_BACKOFF_MS',
+    1_000,
+    { min: 0 },
+    violations,
+  );
+  const WEBHOOK_TIMEOUT_MS = optionalInt(
+    env,
+    'WEBHOOK_TIMEOUT_MS',
+    10_000,
+    { min: 100 },
+    violations,
+  );
+  const WEBHOOK_MAX_CONSECUTIVE_FAILURES = optionalInt(
+    env,
+    'WEBHOOK_MAX_CONSECUTIVE_FAILURES',
+    10,
+    { min: 1 },
+    violations,
+  );
+  const AUTH_RATE_LIMIT_MAX = optionalInt(
+    env,
+    'AUTH_RATE_LIMIT_MAX',
+    10,
+    { min: 1 },
+    violations,
+  );
+  const AUTH_RATE_LIMIT_WINDOW_MS = optionalInt(
+    env,
+    'AUTH_RATE_LIMIT_WINDOW_MS',
+    60_000,
+    { min: 1_000 },
+    violations,
+  );
+  const RATE_LIMIT_WINDOW_MS = optionalInt(
+    env,
+    'RATE_LIMIT_WINDOW_MS',
+    60_000,
+    { min: 1_000 },
+    violations,
+  );
+  const RATE_LIMIT_MAX_REQUESTS = optionalInt(
+    env,
+    'RATE_LIMIT_MAX_REQUESTS',
+    100,
+    { min: 1 },
+    violations,
+  );
+  const RATE_LIMIT_SENSITIVE_WINDOW_MS = optionalInt(
+    env,
+    'RATE_LIMIT_SENSITIVE_WINDOW_MS',
+    60_000,
+    { min: 1_000 },
+    violations,
+  );
+  const RATE_LIMIT_SENSITIVE_MAX_REQUESTS = optionalInt(
+    env,
+    'RATE_LIMIT_SENSITIVE_MAX_REQUESTS',
+    10,
+    { min: 1 },
+    violations,
+  );
+  const API_KEY_ROTATION_GRACE_SECONDS = optionalInt(
+    env,
+    'API_KEY_ROTATION_GRACE_SECONDS',
+    3_600,
+    { min: 0 },
+    violations,
+  );
+
+  // ── Report violations ─────────────────────────────────────────────────────
+  if (violations.length > 0) {
+    const lines = violations.map((v) => `  • ${v.message}`).join('\n');
+    const message =
+      `\n[Env Validation] Application startup aborted — ` +
+      `${violations.length} environment variable problem(s) found:\n${lines}\n\n` +
+      `Please review your .env file against .env.example and fix the issues above.\n`;
+
+    if (process.env.NODE_ENV === 'test') {
+      // In Jest we throw so assertions can catch the error message.
+      throw new Error(message);
+    }
+
+    // In production / development we write to stderr and exit hard.
+    process.stderr.write(message);
+    process.exit(1);
+  }
+
+  return {
+    DATABASE_URL,
+    PORT,
+    WALLET_ENCRYPTION_KEY,
+    STELLAR_HORIZON_URL,
+    BALANCE_STALE_THRESHOLD_MS,
+    WEBHOOK_MAX_RETRIES,
+    WEBHOOK_RETRY_BACKOFF_MS,
+    WEBHOOK_TIMEOUT_MS,
+    WEBHOOK_MAX_CONSECUTIVE_FAILURES,
+    AUTH_RATE_LIMIT_MAX,
+    AUTH_RATE_LIMIT_WINDOW_MS,
+    RATE_LIMIT_WINDOW_MS,
+    RATE_LIMIT_MAX_REQUESTS,
+    RATE_LIMIT_SENSITIVE_WINDOW_MS,
+    RATE_LIMIT_SENSITIVE_MAX_REQUESTS,
+    API_KEY_ROTATION_GRACE_SECONDS,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,14 @@ import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 import requestLogger from './common/middleware/request-logging.middleware';
+import { validateEnv } from './config/env.validation';
 
 async function bootstrap() {
+  // Validate all required environment variables before anything else starts.
+  // This will exit the process with a clear error message if any variable is
+  // missing or invalid, preventing silent runtime failures later.
+  validateEnv(process.env);
+
   const app = await NestFactory.create(AppModule);
   // Attach request logging middleware early in the pipeline
   app.use(requestLogger as any);


### PR DESCRIPTION
Summary 

Closes #315 
Closes #316 

1. Auth Metrics Instrumentation
AuthMetricsService tracks auth attempt counts by outcome (new user, returning user, invalid payload, inactive user, wallet error, etc.), rate-limit hits, and request latency (average + P95)
Wired into AuthOrchestrator and AuthRateLimitGuard
New GET /auth/metrics endpoint exposes a live snapshot
Full unit + integration test coverage


2. Env Validation at Startup
validateEnv() runs before NestJS bootstraps and checks all 16 env vars — required ones (DATABASE_URL, WALLET_ENCRYPTION_KEY, STELLAR_HORIZON_URL) and optional ones with range/type guards
Reports every problem at once instead of failing one at a time
Prevents silent runtime failures from missing config
Full unit test coverage