### PR TITLE
feat(transactions): add pagination metadata response (#340)

### DIFF
--- a/src/transactions/dto/paginated-transactions.dto.ts
+++ b/src/transactions/dto/paginated-transactions.dto.ts
@@ -1,0 +1,9 @@
+import { Transaction } from '../entities/transaction.entity';
+
+export class PaginatedTransactionsDto {
+  data: Transaction[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}

--- a/src/transactions/transactions.controller.spec.ts
+++ b/src/transactions/transactions.controller.spec.ts
@@ -77,7 +77,8 @@ describe('TransactionsController', () => {
 
     it('should return the result from the service', async () => {
       const tx = { id: 'tx-1', status: TransactionStatus.PENDING };
-      mockTransactionsService.findByWallet.mockResolvedValue([tx]);
+      const paginated = { data: [tx], total: 1, limit: 20, offset: 0, hasMore: false };
+      mockTransactionsService.findByWallet.mockResolvedValue(paginated);
 
       const result = await controller.findByWallet(
         'wallet-1',
@@ -85,7 +86,7 @@ describe('TransactionsController', () => {
         undefined,
       );
 
-      expect(result).toEqual([tx]);
+      expect(result).toEqual(paginated);
     });
   });
 

--- a/src/transactions/transactions.service.spec.ts
+++ b/src/transactions/transactions.service.spec.ts
@@ -43,6 +43,7 @@ const mockPrisma = {
     create: jest.fn(),
     findUnique: jest.fn(),
     findMany: jest.fn(),
+    count: jest.fn(),
     update: jest.fn(),
   },
 };
@@ -167,30 +168,59 @@ describe('TransactionsService', () => {
   });
 
   describe('findAll', () => {
-    it('returns all transactions without filters', async () => {
+    it('returns paginated transactions without filters', async () => {
       const txs = [makePrismaTransaction()];
       mockPrisma.transaction.findMany.mockResolvedValue(txs);
+      mockPrisma.transaction.count.mockResolvedValue(1);
 
       const result = await service.findAll();
 
       expect(mockPrisma.transaction.findMany).toHaveBeenCalledWith({
         where: {},
         orderBy: { createdAt: 'desc' },
-        take: undefined,
-        skip: undefined,
+        take: 20,
+        skip: 0,
       });
-      expect(result).toHaveLength(1);
+      expect(result.data).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.limit).toBe(20);
+      expect(result.offset).toBe(0);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('uses provided limit and offset', async () => {
+      mockPrisma.transaction.findMany.mockResolvedValue([]);
+      mockPrisma.transaction.count.mockResolvedValue(10);
+
+      const result = await service.findAll({ limit: 5, offset: 5 });
+
+      expect(result.limit).toBe(5);
+      expect(result.offset).toBe(5);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('sets hasMore=true when more results exist', async () => {
+      const txs = [makePrismaTransaction()];
+      mockPrisma.transaction.findMany.mockResolvedValue(txs);
+      mockPrisma.transaction.count.mockResolvedValue(5);
+
+      const result = await service.findAll({ limit: 1, offset: 0 });
+
+      expect(result.hasMore).toBe(true);
     });
   });
 
   describe('findByWallet', () => {
-    it('returns transactions for a valid wallet', async () => {
+    it('returns paginated transactions for a valid wallet', async () => {
       mockPrisma.wallet.findUnique.mockResolvedValue({ id: 'wallet-1' });
       mockPrisma.transaction.findMany.mockResolvedValue([makePrismaTransaction()]);
+      mockPrisma.transaction.count.mockResolvedValue(1);
 
       const result = await service.findByWallet('wallet-1');
 
-      expect(result).toHaveLength(1);
+      expect(result.data).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.hasMore).toBe(false);
     });
 
     it('throws NotFoundException when wallet does not exist', async () => {

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -3,7 +3,6 @@ import {
   Logger,
   NotFoundException,
   BadRequestException,
-  Optional,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { BalanceIndexerService } from '../balance-indexer/balance-indexer.service';
@@ -20,6 +19,7 @@ import {
   StellarNetworkReferences,
 } from './domain/transaction.model';
 import { Transaction as TransactionEntity } from './entities/transaction.entity';
+import { PaginatedTransactionsDto } from './dto/paginated-transactions.dto';
 import { InsufficientBalanceException } from './domain/insufficient-balance.exception';
 import { WebhookEventEmitterService } from '../webhooks/webhook-event-emitter.service';
 
@@ -137,7 +137,7 @@ export class TransactionsService {
   }
 
   /**
-   * Find all transactions with optional filters
+   * Find all transactions with optional filters, returns paginated response
    */
   async findAll(filters?: {
     senderWalletId?: string;
@@ -145,7 +145,7 @@ export class TransactionsService {
     status?: TransactionStatus;
     limit?: number;
     offset?: number;
-  }): Promise<TransactionEntity[]> {
+  }): Promise<PaginatedTransactionsDto> {
     const where: any = {};
 
     if (filters?.senderWalletId) {
@@ -160,14 +160,26 @@ export class TransactionsService {
       where.status = filters.status;
     }
 
-    const transactions = await this.prisma.transaction.findMany({
-      where,
-      orderBy: { createdAt: 'desc' },
-      take: filters?.limit,
-      skip: filters?.offset,
-    });
+    const limit = filters?.limit ?? 20;
+    const offset = filters?.offset ?? 0;
 
-    return transactions.map((t) => this.mapPrismaToEntity(t));
+    const [transactions, total] = await Promise.all([
+      this.prisma.transaction.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+        skip: offset,
+      }),
+      this.prisma.transaction.count({ where }),
+    ]);
+
+    return {
+      data: transactions.map((t) => this.mapPrismaToEntity(t)),
+      total,
+      limit,
+      offset,
+      hasMore: offset + transactions.length < total,
+    };
   }
 
   /**
@@ -274,12 +286,12 @@ export class TransactionsService {
   }
 
   /**
-   * Find transactions by wallet ID with pagination
+   * Find transactions by wallet ID with pagination metadata
    */
   async findByWallet(
     walletId: string,
     pagination?: { limit?: number; offset?: number },
-  ): Promise<TransactionEntity[]> {
+  ): Promise<PaginatedTransactionsDto> {
     const wallet = await this.prisma.wallet.findUnique({
       where: { id: walletId },
     });
@@ -288,16 +300,29 @@ export class TransactionsService {
       throw new NotFoundException(`Wallet ${walletId} not found`);
     }
 
-    const transactions = await this.prisma.transaction.findMany({
-      where: {
-        OR: [{ senderWalletId: walletId }, { receiverWalletId: walletId }],
-      },
-      orderBy: { createdAt: 'desc' },
-      take: pagination?.limit,
-      skip: pagination?.offset,
-    });
+    const limit = pagination?.limit ?? 20;
+    const offset = pagination?.offset ?? 0;
+    const where = {
+      OR: [{ senderWalletId: walletId }, { receiverWalletId: walletId }],
+    };
 
-    return transactions.map((t) => this.mapPrismaToEntity(t));
+    const [transactions, total] = await Promise.all([
+      this.prisma.transaction.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+        skip: offset,
+      }),
+      this.prisma.transaction.count({ where }),
+    ]);
+
+    return {
+      data: transactions.map((t) => this.mapPrismaToEntity(t)),
+      total,
+      limit,
+      offset,
+      hasMore: offset + transactions.length < total,
+    };
   }
 
   /**


### PR DESCRIPTION
- findAll and findByWallet now return PaginatedTransactionsDto with data, total, limit, offset, hasMore fields
- Default limit is 20, default offset is 0
- Update service spec and controller spec accordingly

Closes #340