### PR TITLE
Feat/webhooks and balance indexer 379 382

### DIFF
--- a/src/balance-indexer/balance-indexer.integration.spec.ts
+++ b/src/balance-indexer/balance-indexer.integration.spec.ts
@@ -1,0 +1,280 @@
+/**
+ * BalanceIndexerService integration harness (#382)
+ *
+ * Wires BalanceIndexerService with an in-memory Prisma stub to exercise
+ * event indexing, idempotency, ordering, and retry behaviour.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '@nestjs/common';
+import { BalanceIndexerService } from './balance-indexer.service';
+import { StellarHorizonService } from './stellar-horizon.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { WebhookEventEmitterService } from '../webhooks/webhook-event-emitter.service';
+import {
+  AssetType,
+  BalanceChangeEvent,
+  BalanceSyncStatus,
+} from './domain/balance.model';
+
+const WALLET_ID = 'wallet-integration-1';
+const NOW = new Date('2026-06-01T12:00:00.000Z');
+
+const nativeEvent = (
+  overrides: Partial<BalanceChangeEvent> = {},
+): BalanceChangeEvent => ({
+  walletId: WALLET_ID,
+  asset: { type: AssetType.NATIVE },
+  balance: '100.0000000',
+  ledgerSequence: 1000,
+  transactionHash: 'tx-hash-1',
+  timestamp: NOW,
+  ...overrides,
+});
+
+const creditEvent = (
+  overrides: Partial<BalanceChangeEvent> = {},
+): BalanceChangeEvent => ({
+  walletId: WALLET_ID,
+  asset: {
+    type: AssetType.CREDIT_ALPHANUM4,
+    code: 'USDC',
+    issuer: 'GUSDC123',
+  },
+  balance: '25.0000000',
+  ledgerSequence: 1001,
+  transactionHash: 'tx-hash-usdc-1',
+  timestamp: NOW,
+  ...overrides,
+});
+
+describe('BalanceIndexerService (integration harness)', () => {
+  let service: BalanceIndexerService;
+  let balanceStore: Map<string, any>;
+  let mockPrisma: any;
+  let mockHorizon: {
+    getAccountBalances: jest.Mock;
+    accountExists: jest.Mock;
+  };
+  let syncWalletBalancesSpy: jest.SpyInstance;
+
+  const compoundKey = (walletId: string, asset: BalanceChangeEvent['asset']) =>
+    [
+      walletId,
+      asset.type,
+      asset.code ?? null,
+      asset.issuer ?? null,
+    ].join('|');
+
+  beforeEach(async () => {
+    balanceStore = new Map();
+    mockHorizon = {
+      getAccountBalances: jest.fn(),
+      accountExists: jest.fn(),
+    };
+
+    mockPrisma = {
+      walletBalance: {
+        findUnique: jest.fn(({ where }) => {
+          const key = compoundKey(
+            where.walletId_assetType_assetCode_assetIssuer.walletId,
+            {
+              type: where.walletId_assetType_assetCode_assetIssuer.assetType,
+              code:
+                where.walletId_assetType_assetCode_assetIssuer.assetCode ??
+                undefined,
+              issuer:
+                where.walletId_assetType_assetCode_assetIssuer.assetIssuer ??
+                undefined,
+            },
+          );
+          return Promise.resolve(balanceStore.get(key) ?? null);
+        }),
+        findMany: jest.fn(({ where }) => {
+          const rows = [...balanceStore.values()].filter(
+            (row) => row.walletId === where.walletId,
+          );
+          return Promise.resolve(rows);
+        }),
+        upsert: jest.fn(({ where, create, update }) => {
+          const key = compoundKey(
+            where.walletId_assetType_assetCode_assetIssuer.walletId,
+            {
+              type: where.walletId_assetType_assetCode_assetIssuer.assetType,
+              code:
+                where.walletId_assetType_assetCode_assetIssuer.assetCode ??
+                undefined,
+              issuer:
+                where.walletId_assetType_assetCode_assetIssuer.assetIssuer ??
+                undefined,
+            },
+          );
+          const existing = balanceStore.get(key);
+          const row = existing
+            ? { ...existing, ...update }
+            : { id: `bal-${balanceStore.size + 1}`, ...create };
+          balanceStore.set(key, row);
+          return Promise.resolve(row);
+        }),
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      wallet: {
+        findUnique: jest.fn(),
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      balanceSyncJob: {
+        create: jest.fn().mockResolvedValue({ id: 'job-1' }),
+        update: jest.fn().mockResolvedValue({}),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BalanceIndexerService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: StellarHorizonService, useValue: mockHorizon },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((_key: string, defaultValue?: unknown) => defaultValue),
+          },
+        },
+        {
+          provide: WebhookEventEmitterService,
+          useValue: {
+            emitBalanceUpdated: jest.fn(),
+            emitBalanceMismatch: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<BalanceIndexerService>(BalanceIndexerService);
+    syncWalletBalancesSpy = jest
+      .spyOn(service, 'syncWalletBalances')
+      .mockResolvedValue({
+        walletId: WALLET_ID,
+        balancesUpdated: 1,
+        mismatchesFound: 0,
+        syncStatus: BalanceSyncStatus.SYNCED,
+        lastSyncedAt: NOW,
+      });
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
+    jest.restoreAllMocks();
+  });
+
+  it('indexes a new balance event and creates a DB record', async () => {
+    const event = nativeEvent();
+
+    const result = await service.indexBalanceEvent(event);
+
+    expect(result).toEqual({ action: 'indexed' });
+    expect(mockPrisma.walletBalance.upsert).toHaveBeenCalledTimes(1);
+    const stored = await mockPrisma.walletBalance.findMany({
+      where: { walletId: WALLET_ID },
+    });
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({
+      walletId: WALLET_ID,
+      balance: '100.0000000',
+      lastSyncedLedger: 1000,
+      assetType: AssetType.NATIVE,
+    });
+  });
+
+  it('updates an existing balance for the same account and asset', async () => {
+    await service.indexBalanceEvent(nativeEvent());
+    await service.indexBalanceEvent(
+      nativeEvent({
+        balance: '150.0000000',
+        ledgerSequence: 1005,
+        transactionHash: 'tx-hash-2',
+      }),
+    );
+
+    const stored = await mockPrisma.walletBalance.findMany({
+      where: { walletId: WALLET_ID },
+    });
+    expect(stored).toHaveLength(1);
+    expect(stored[0].balance).toBe('150.0000000');
+    expect(stored[0].lastSyncedLedger).toBe(1005);
+  });
+
+  it('is idempotent for duplicate ledger sequence and transaction hash', async () => {
+    const event = nativeEvent();
+
+    await service.indexBalanceEvent(event);
+    await service.indexBalanceEvent(event);
+
+    expect(mockPrisma.walletBalance.upsert).toHaveBeenCalledTimes(1);
+    const stored = await mockPrisma.walletBalance.findMany({
+      where: { walletId: WALLET_ID },
+    });
+    expect(stored).toHaveLength(1);
+  });
+
+  it('does not overwrite a newer balance with an older out-of-order event', async () => {
+    await service.indexBalanceEvent(
+      nativeEvent({
+        balance: '200.0000000',
+        ledgerSequence: 2000,
+        transactionHash: 'tx-newer',
+      }),
+    );
+
+    const result = await service.indexBalanceEvent(
+      nativeEvent({
+        balance: '50.0000000',
+        ledgerSequence: 1500,
+        transactionHash: 'tx-older',
+      }),
+    );
+
+    expect(result).toEqual({ action: 'skipped', reason: 'out_of_order' });
+    const stored = await mockPrisma.walletBalance.findMany({
+      where: { walletId: WALLET_ID },
+    });
+    expect(stored[0].balance).toBe('200.0000000');
+    expect(stored[0].lastSyncedLedger).toBe(2000);
+  });
+
+  it('creates separate balance records for multiple assets on the same account', async () => {
+    await service.indexBalanceEvent(nativeEvent());
+    await service.indexBalanceEvent(creditEvent());
+
+    const stored = await mockPrisma.walletBalance.findMany({
+      where: { walletId: WALLET_ID },
+    });
+    expect(stored).toHaveLength(2);
+    expect(stored.map((row) => row.assetType).sort()).toEqual([
+      AssetType.CREDIT_ALPHANUM4,
+      AssetType.NATIVE,
+    ]);
+  });
+
+  it('retries indexing when the database is temporarily unavailable', async () => {
+    const warnSpy = jest
+      .spyOn(Logger.prototype, 'warn')
+      .mockImplementation(() => undefined);
+    syncWalletBalancesSpy.mockRestore();
+
+    mockPrisma.wallet.findUnique
+      .mockRejectedValueOnce(new Error('connection refused'))
+      .mockResolvedValueOnce({ id: WALLET_ID, publicKey: 'GABC123' });
+    mockHorizon.accountExists.mockResolvedValue(true);
+    mockHorizon.getAccountBalances.mockResolvedValue([]);
+
+    const result = await service.syncWalletBalancesWithRetry({
+      walletId: WALLET_ID,
+    });
+
+    expect(result.walletId).toBe(WALLET_ID);
+    expect(mockPrisma.wallet.findUnique).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Sync retry 1/3'),
+    );
+  });
+});

--- a/src/balance-indexer/balance-indexer.service.ts
+++ b/src/balance-indexer/balance-indexer.service.ts
@@ -15,6 +15,8 @@ import {
   AssetType,
   BalanceSyncStatus,
   BalanceUpdate,
+  BalanceChangeEvent,
+  IndexBalanceEventResult,
   ReconciliationResult,
 } from './domain/balance.model';
 
@@ -77,6 +79,7 @@ export class BalanceIndexerService implements OnModuleInit, OnModuleDestroy {
   private readonly syncIntervalMs: number;
   private readonly maxRetries: number;
   private syncTimer: NodeJS.Timeout | null = null;
+  private readonly processedEventKeys = new Set<string>();
 
   constructor(
     private readonly prisma: PrismaService,
@@ -193,6 +196,65 @@ export class BalanceIndexerService implements OnModuleInit, OnModuleDestroy {
     }
 
     return { walletId, staleAssets, staleSince: oldestStale };
+  }
+
+  /**
+   * Indexes a Stellar balance-change event with idempotency and ordering guards.
+   */
+  async indexBalanceEvent(
+    event: BalanceChangeEvent,
+  ): Promise<IndexBalanceEventResult> {
+    const eventKey = this.buildBalanceEventKey(event);
+    if (this.processedEventKeys.has(eventKey)) {
+      return { action: 'skipped', reason: 'duplicate' };
+    }
+
+    const existing = await this.prisma.walletBalance.findUnique({
+      where: {
+        walletId_assetType_assetCode_assetIssuer: this.assetCompoundKey(
+          event.walletId,
+          event.asset,
+        ),
+      },
+    });
+
+    if (
+      existing?.lastSyncedLedger != null &&
+      event.ledgerSequence < existing.lastSyncedLedger
+    ) {
+      return { action: 'skipped', reason: 'out_of_order' };
+    }
+
+    await this.prisma.walletBalance.upsert({
+      where: {
+        walletId_assetType_assetCode_assetIssuer: this.assetCompoundKey(
+          event.walletId,
+          event.asset,
+        ),
+      },
+      create: {
+        walletId: event.walletId,
+        assetType: event.asset.type,
+        assetCode: event.asset.code || null,
+        assetIssuer: event.asset.issuer || null,
+        balance: event.balance,
+        syncStatus: BalanceSyncStatus.SYNCED,
+        lastSyncedAt: event.timestamp,
+        lastSyncedLedger: event.ledgerSequence,
+        onChainBalance: event.balance,
+      },
+      update: {
+        balance: event.balance,
+        syncStatus: BalanceSyncStatus.SYNCED,
+        lastSyncedAt: event.timestamp,
+        lastSyncedLedger: event.ledgerSequence,
+        onChainBalance: event.balance,
+        updatedAt: new Date(),
+      },
+    });
+
+    this.processedEventKeys.add(eventKey);
+    return { action: 'indexed' };
   }
 
   /**
@@ -668,6 +730,17 @@ export class BalanceIndexerService implements OnModuleInit, OnModuleDestroy {
       asset1.code === asset2.code &&
       asset1.issuer === asset2.issuer
     );
+  }
+
+  private buildBalanceEventKey(event: BalanceChangeEvent): string {
+    return [
+      event.walletId,
+      event.asset.type,
+      event.asset.code ?? '',
+      event.asset.issuer ?? '',
+      event.ledgerSequence,
+      event.transactionHash,
+    ].join(':');
   }
 
   private assetCompoundKey(walletId: string, asset: Asset) {

--- a/src/balance-indexer/domain/balance.model.ts
+++ b/src/balance-indexer/domain/balance.model.ts
@@ -49,6 +49,15 @@ export interface BalanceUpdate {
   timestamp: Date;
 }
 
+export interface BalanceChangeEvent extends BalanceUpdate {
+  transactionHash: string;
+}
+
+export type IndexBalanceEventResult = {
+  action: 'indexed' | 'skipped';
+  reason?: 'duplicate' | 'out_of_order';
+};
+
 export interface ReconciliationResult {
   walletId: string;
   asset: Asset;

--- a/src/common/context/request-context.ts
+++ b/src/common/context/request-context.ts
@@ -1,0 +1,17 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+export interface RequestContextStore {
+  requestId: string;
+}
+
+const storage = new AsyncLocalStorage<RequestContextStore>();
+
+export class RequestContext {
+  static run<T>(requestId: string, fn: () => T): T {
+    return storage.run({ requestId }, fn);
+  }
+
+  static getRequestId(): string | undefined {
+    return storage.getStore()?.requestId;
+  }
+}

--- a/src/common/middleware/request-logging.middleware.spec.ts
+++ b/src/common/middleware/request-logging.middleware.spec.ts
@@ -1,5 +1,6 @@
 import requestLogger from './request-logging.middleware';
 import { Logger } from '@nestjs/common';
+import { RequestContext } from '../context/request-context';
 
 describe('requestLogger', () => {
   beforeEach(() => jest.restoreAllMocks());
@@ -37,6 +38,76 @@ describe('requestLogger', () => {
     // simulate finish handlers
     finishCallbacks.finish.forEach((cb) => cb());
     expect(spyLog).toHaveBeenCalled();
+  });
+
+  it('propagates incoming x-request-id to response and request headers', () => {
+    const incomingId = 'incoming-request-id-abc';
+    const req: any = {
+      method: 'GET',
+      originalUrl: '/webhooks/endpoints/1',
+      headers: { 'x-request-id': incomingId },
+      ip: '1.2.3.4',
+    };
+    const res: any = {
+      setHeader: jest.fn(),
+      on: jest.fn(),
+      statusCode: 200,
+    };
+    const next = jest.fn();
+
+    requestLogger(req, res, next as any);
+
+    expect(req.headers['x-request-id']).toBe(incomingId);
+    expect(res.setHeader).toHaveBeenCalledWith('x-request-id', incomingId);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('generates a UUID when x-request-id is absent', () => {
+    const req: any = {
+      method: 'POST',
+      originalUrl: '/webhooks/endpoints',
+      headers: {},
+      ip: '1.2.3.4',
+    };
+    const res: any = {
+      setHeader: jest.fn(),
+      on: jest.fn(),
+      statusCode: 201,
+    };
+    const next = jest.fn();
+
+    requestLogger(req, res, next as any);
+
+    expect(req.headers['x-request-id']).toEqual(expect.any(String));
+    expect(req.headers['x-request-id']).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'x-request-id',
+      req.headers['x-request-id'],
+    );
+  });
+
+  it('runs downstream handlers within RequestContext', () => {
+    const req: any = {
+      method: 'GET',
+      originalUrl: '/test',
+      headers: { 'x-request-id': 'ctx-test-id' },
+      ip: '1.2.3.4',
+    };
+    const res: any = {
+      setHeader: jest.fn(),
+      on: jest.fn(),
+      statusCode: 200,
+    };
+    let capturedId: string | undefined;
+    const next = jest.fn(() => {
+      capturedId = RequestContext.getRequestId();
+    });
+
+    requestLogger(req, res, next as any);
+
+    expect(capturedId).toBe('ctx-test-id');
   });
 
   it('handles invalid/stale request objects gracefully', () => {

--- a/src/common/middleware/request-logging.middleware.ts
+++ b/src/common/middleware/request-logging.middleware.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
+import { RequestContext } from '../context/request-context';
 
 export function requestLogger(
   req: Request | any,
@@ -8,15 +9,15 @@ export function requestLogger(
   next: NextFunction,
 ) {
   const logger = new Logger('RequestLogger');
-  try {
-    if (!req) {
-      logger.warn('Request logging skipped: invalid request object');
-      next();
-      return;
-    }
 
+  if (!req) {
+    logger.warn('Request logging skipped: invalid request object');
+    next();
+    return;
+  }
+
+  try {
     const idHeader =
-      req &&
       req.headers &&
       (req.headers['x-request-id'] || req.headers['X-Request-Id']);
     const id =
@@ -24,6 +25,10 @@ export function requestLogger(
         ? idHeader
         : randomUUID();
     const start = Date.now();
+
+    if (req.headers) {
+      req.headers['x-request-id'] = id;
+    }
 
     if (res && typeof res.setHeader === 'function') {
       try {
@@ -53,9 +58,16 @@ export function requestLogger(
         }
       });
     }
+
+    RequestContext.run(id, () => {
+      try {
+        next();
+      } catch (e) {
+        logger.warn('next() threw in requestLogger');
+      }
+    });
   } catch (err: any) {
     logger.warn('Request logging failed: ' + (err && err.message));
-  } finally {
     try {
       next();
     } catch (e) {

--- a/src/common/services/feature-flag.service.ts
+++ b/src/common/services/feature-flag.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class FeatureFlagService {
+  constructor(private readonly configService: ConfigService) {}
+
+  isEnabled(flagName: string, defaultValue = false): boolean {
+    const raw = this.configService.get<string>(flagName);
+    if (raw === undefined || raw === null || raw === '') {
+      return defaultValue;
+    }
+    return raw.toLowerCase() === 'true' || raw === '1';
+  }
+}

--- a/src/webhooks/webhook-cache.service.ts
+++ b/src/webhooks/webhook-cache.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+
+export const WEBHOOK_CACHE_TTL_MS = 60_000;
+
+interface CacheEntry {
+  value: unknown;
+  expiresAt: number;
+}
+
+// TODO: replace with Redis-backed cache for multi-instance deployments
+@Injectable()
+export class WebhookCacheService {
+  private readonly store = new Map<string, CacheEntry>();
+
+  get<T>(key: string): T | undefined {
+    const entry = this.store.get(key);
+    if (!entry) {
+      return undefined;
+    }
+    if (Date.now() >= entry.expiresAt) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry.value as T;
+  }
+
+  set(key: string, value: unknown, ttlMs: number = WEBHOOK_CACHE_TTL_MS): void {
+    this.store.set(key, {
+      value,
+      expiresAt: Date.now() + ttlMs,
+    });
+  }
+
+  invalidate(key: string): void {
+    this.store.delete(key);
+  }
+
+  endpointKey(endpointId: string): string {
+    return `webhook:endpoint:${endpointId}`;
+  }
+}

--- a/src/webhooks/webhook-dispatcher.service.spec.ts
+++ b/src/webhooks/webhook-dispatcher.service.spec.ts
@@ -1,0 +1,107 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import { WebhookDispatcherService } from './webhook-dispatcher.service';
+import { WebhookSignerService } from './webhook-signer.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { RequestContext } from '../common/context/request-context';
+import {
+  DeliveryStatus,
+  EndpointStatus,
+  WebhookEventType,
+} from './domain/webhook-events';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const ENDPOINT_ID = 'endpoint-1';
+const DELIVERY_ID = 'delivery-1';
+const REQUEST_ID = 'test-request-id-379';
+
+const mockDelivery = {
+  id: DELIVERY_ID,
+  endpointId: ENDPOINT_ID,
+  eventId: 'event-1',
+  eventType: WebhookEventType.WALLET_CREATED,
+  payload: { id: 'event-1', type: WebhookEventType.WALLET_CREATED },
+  status: DeliveryStatus.PENDING,
+  attempts: 0,
+  endpoint: {
+    id: ENDPOINT_ID,
+    url: 'https://example.com/hook',
+    secret: 'whsec_test',
+    status: EndpointStatus.ACTIVE,
+  },
+};
+
+describe('WebhookDispatcherService (request ID propagation)', () => {
+  let service: WebhookDispatcherService;
+
+  const mockPrisma = {
+    webhookDelivery: {
+      findMany: jest.fn(),
+      update: jest.fn(),
+    },
+    webhookEndpoint: {
+      update: jest.fn(),
+    },
+  };
+
+  const mockSigner = {
+    generateSignatureHeaders: jest.fn().mockReturnValue({
+      timestamp: 1234567890,
+      signature: 'sig',
+    }),
+    formatSignatureHeader: jest.fn().mockReturnValue('t=1234567890,v1=sig'),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockedAxios.post.mockResolvedValue({ status: 200, data: { ok: true } });
+    mockPrisma.webhookDelivery.findMany.mockResolvedValue([mockDelivery]);
+    mockPrisma.webhookDelivery.update.mockResolvedValue({});
+    mockPrisma.webhookEndpoint.update.mockResolvedValue({});
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookDispatcherService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: WebhookSignerService, useValue: mockSigner },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((_key: string, defaultValue?: unknown) => defaultValue),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<WebhookDispatcherService>(WebhookDispatcherService);
+  });
+
+  it('forwards x-request-id on outbound webhook HTTP calls when present in context', async () => {
+    await RequestContext.run(REQUEST_ID, async () => {
+      await service.processDeliveries();
+    });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      mockDelivery.endpoint.url,
+      mockDelivery.payload,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-request-id': REQUEST_ID,
+        }),
+      }),
+    );
+  });
+
+  it('omits x-request-id on outbound calls when no request context exists', async () => {
+    await service.processDeliveries();
+
+    const callHeaders = mockedAxios.post.mock.calls[0][2]?.headers as Record<
+      string,
+      string
+    >;
+    expect(callHeaders['x-request-id']).toBeUndefined();
+  });
+});

--- a/src/webhooks/webhook-dispatcher.service.ts
+++ b/src/webhooks/webhook-dispatcher.service.ts
@@ -9,6 +9,8 @@ import {
   EndpointStatus,
 } from './domain/webhook-events';
 import axios, { AxiosError } from 'axios';
+import { RequestContext } from '../common/context/request-context';
+import { logWebhookOperation } from './webhook-logging.util';
 
 export interface DispatchEventRequest {
   event: WebhookEvent;
@@ -60,17 +62,32 @@ export class WebhookDispatcherService {
   async dispatchEvent(request: DispatchEventRequest): Promise<void> {
     const { event, projectId } = request;
 
-    this.logger.log(`Dispatching event ${event.type} (${event.id})`);
+    logWebhookOperation(
+      this.logger,
+      'log',
+      `Dispatching event ${event.type} (${event.id})`,
+      { eventType: event.type, eventId: event.id },
+    );
 
     // Find all endpoints subscribed to this event type
     const endpoints = await this.findSubscribedEndpoints(event.type, projectId);
 
     if (endpoints.length === 0) {
-      this.logger.log(`No endpoints subscribed to ${event.type}`);
+      logWebhookOperation(
+        this.logger,
+        'log',
+        `No endpoints subscribed to ${event.type}`,
+        { eventType: event.type },
+      );
       return;
     }
 
-    this.logger.log(`Found ${endpoints.length} endpoints for ${event.type}`);
+    logWebhookOperation(
+      this.logger,
+      'log',
+      `Found ${endpoints.length} endpoints for ${event.type}`,
+      { eventType: event.type, endpointCount: endpoints.length },
+    );
 
     // Create delivery records for each endpoint
     for (const endpoint of endpoints) {
@@ -79,7 +96,12 @@ export class WebhookDispatcherService {
 
     // Attempt immediate delivery (async)
     this.processDeliveries().catch((err) =>
-      this.logger.error('Background delivery processing failed:', err),
+      logWebhookOperation(
+        this.logger,
+        'error',
+        'Background delivery processing failed',
+        { error: err?.message },
+      ),
     );
   }
 
@@ -127,15 +149,23 @@ export class WebhookDispatcherService {
           retrying++;
         }
       } catch (error) {
-        this.logger.error(`Delivery attempt failed for ${delivery.id}:`, error);
+        logWebhookOperation(
+          this.logger,
+          'error',
+          `Delivery attempt failed for ${delivery.id}`,
+          { deliveryId: delivery.id, error: error?.message },
+        );
         failed++;
       }
     }
 
     const duration = Date.now() - startTime;
-    this.logger.log(
+    logWebhookOperation(
+      this.logger,
+      'log',
       `Processed ${deliveries.length} deliveries in ${duration}ms ` +
         `(delivered: ${delivered}, failed: ${failed}, retrying: ${retrying})`,
+      { delivered, failed, retrying, durationMs: duration },
     );
 
     return { delivered, failed, retrying };
@@ -149,15 +179,28 @@ export class WebhookDispatcherService {
 
     // Skip disabled endpoints
     if (endpoint.status !== EndpointStatus.ACTIVE) {
-      this.logger.warn(`Skipping delivery to disabled endpoint ${endpoint.id}`);
+      logWebhookOperation(
+        this.logger,
+        'warn',
+        `Skipping delivery to disabled endpoint ${endpoint.id}`,
+        { endpointId: endpoint.id, deliveryId: delivery.id },
+      );
       return DeliveryStatus.FAILED;
     }
 
     const attemptNumber = delivery.attempts + 1;
     const startTime = Date.now();
 
-    this.logger.log(
+    logWebhookOperation(
+      this.logger,
+      'log',
       `Attempting delivery ${delivery.id} to ${endpoint.url} (attempt ${attemptNumber}/${this.maxRetries})`,
+      {
+        deliveryId: delivery.id,
+        endpointId: endpoint.id,
+        attempt: attemptNumber,
+        maxAttempts: this.maxRetries,
+      },
     );
 
     try {
@@ -168,18 +211,24 @@ export class WebhookDispatcherService {
           endpoint.secret,
         );
 
+      const requestId = RequestContext.getRequestId();
+      const outboundHeaders: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'X-Webhook-Event-Type': delivery.eventType,
+        'X-Webhook-Event-Id': delivery.eventId,
+        'X-Webhook-Signature': this.webhookSigner.formatSignatureHeader(
+          timestamp,
+          signature,
+        ),
+        'User-Agent': 'Mux-Webhooks/1.0',
+      };
+      if (requestId) {
+        outboundHeaders['x-request-id'] = requestId;
+      }
+
       // Make HTTP request
       const response = await axios.post(endpoint.url, delivery.payload, {
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Webhook-Event-Type': delivery.eventType,
-          'X-Webhook-Event-Id': delivery.eventId,
-          'X-Webhook-Signature': this.webhookSigner.formatSignatureHeader(
-            timestamp,
-            signature,
-          ),
-          'User-Agent': 'Mux-Webhooks/1.0',
-        },
+        headers: outboundHeaders,
         timeout: this.requestTimeoutMs,
         validateStatus: (status) => status >= 200 && status < 300,
       });
@@ -195,8 +244,11 @@ export class WebhookDispatcherService {
       );
       await this.markEndpointSuccess(endpoint.id);
 
-      this.logger.log(
+      logWebhookOperation(
+        this.logger,
+        'log',
         `Successfully delivered ${delivery.id} in ${responseTime}ms`,
+        { deliveryId: delivery.id, responseTimeMs: responseTime },
       );
       return DeliveryStatus.DELIVERED;
     } catch (error) {
@@ -208,8 +260,15 @@ export class WebhookDispatcherService {
         ? JSON.stringify(axiosError.response.data).substring(0, 500)
         : axiosError.message;
 
-      this.logger.warn(
+      logWebhookOperation(
+        this.logger,
+        'warn',
         `Delivery ${delivery.id} failed (attempt ${attemptNumber}): ${axiosError.message}`,
+        {
+          deliveryId: delivery.id,
+          attempt: attemptNumber,
+          error: axiosError.message,
+        },
       );
 
       // Determine if we should retry
@@ -419,8 +478,11 @@ export class WebhookDispatcherService {
     });
 
     if (shouldDisable) {
-      this.logger.warn(
+      logWebhookOperation(
+        this.logger,
+        'warn',
         `Disabled endpoint ${endpointId} after ${newFailureCount} consecutive failures`,
+        { endpointId, consecutiveFailures: newFailureCount },
       );
     }
   }

--- a/src/webhooks/webhook-logging.util.ts
+++ b/src/webhooks/webhook-logging.util.ts
@@ -1,0 +1,17 @@
+import { Logger } from '@nestjs/common';
+import { RequestContext } from '../common/context/request-context';
+
+export function logWebhookOperation(
+  logger: Logger,
+  level: 'log' | 'warn' | 'error',
+  message: string,
+  meta: Record<string, unknown> = {},
+): void {
+  logger[level](
+    JSON.stringify({
+      message,
+      requestId: RequestContext.getRequestId(),
+      ...meta,
+    }),
+  );
+}

--- a/src/webhooks/webhook.controller.ts
+++ b/src/webhooks/webhook.controller.ts
@@ -9,6 +9,7 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import { WebhookService } from './webhook.service';
 import type {
@@ -16,8 +17,10 @@ import type {
   UpdateWebhookEndpointRequest,
 } from './webhook.service';
 import { WebhookDispatcherService } from './webhook-dispatcher.service';
+import { WebhooksFeatureFlagGuard } from './webhooks-feature-flag.guard';
 
 @Controller('webhooks')
+@UseGuards(WebhooksFeatureFlagGuard)
 export class WebhookController {
   constructor(
     private readonly webhookService: WebhookService,

--- a/src/webhooks/webhook.module.ts
+++ b/src/webhooks/webhook.module.ts
@@ -6,6 +6,9 @@ import { WebhookSignerService } from './webhook-signer.service';
 import { WebhookEventEmitterService } from './webhook-event-emitter.service';
 import { WebhookDeliveryQueueWorker } from './webhook-delivery-queue.worker';
 import { WebhookController } from './webhook.controller';
+import { WebhookCacheService } from './webhook-cache.service';
+import { FeatureFlagService } from '../common/services/feature-flag.service';
+import { WebhooksFeatureFlagGuard } from './webhooks-feature-flag.guard';
 
 @Module({
   imports: [ConfigModule],
@@ -16,6 +19,9 @@ import { WebhookController } from './webhook.controller';
     WebhookSignerService,
     WebhookEventEmitterService,
     WebhookDeliveryQueueWorker,
+    WebhookCacheService,
+    FeatureFlagService,
+    WebhooksFeatureFlagGuard,
   ],
   exports: [WebhookEventEmitterService, WebhookDispatcherService],
 })

--- a/src/webhooks/webhook.service.spec.ts
+++ b/src/webhooks/webhook.service.spec.ts
@@ -3,6 +3,7 @@ import { NotFoundException } from '@nestjs/common';
 import { WebhookService } from './webhook.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { EndpointStatus } from './domain/webhook-events';
+import { WebhookCacheService } from './webhook-cache.service';
 
 const PROJECT_ID = 'project-1';
 const ENDPOINT_ID = 'endpoint-1';
@@ -26,6 +27,7 @@ const mockEndpoint = {
 
 describe('WebhookService', () => {
   let service: WebhookService;
+  let cache: WebhookCacheService;
 
   const mockPrisma = {
     webhookEndpoint: {
@@ -46,11 +48,13 @@ describe('WebhookService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         WebhookService,
+        WebhookCacheService,
         { provide: PrismaService, useValue: mockPrisma },
       ],
     }).compile();
 
     service = module.get<WebhookService>(WebhookService);
+    cache = module.get<WebhookCacheService>(WebhookCacheService);
   });
 
   it('should be defined', () => {
@@ -138,6 +142,24 @@ describe('WebhookService', () => {
         NotFoundException,
       );
     });
+
+    it('returns cached endpoint on second call without hitting DB', async () => {
+      mockPrisma.webhookEndpoint.findUnique.mockResolvedValue(mockEndpoint);
+
+      await service.getEndpoint(ENDPOINT_ID);
+      await service.getEndpoint(ENDPOINT_ID);
+
+      expect(mockPrisma.webhookEndpoint.findUnique).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls through to DB on cache miss', async () => {
+      mockPrisma.webhookEndpoint.findUnique.mockResolvedValue(mockEndpoint);
+
+      const result = await service.getEndpoint(ENDPOINT_ID);
+
+      expect(result.id).toBe(ENDPOINT_ID);
+      expect(mockPrisma.webhookEndpoint.findUnique).toHaveBeenCalledTimes(1);
+    });
   });
 
   // ─── updateEndpoint ──────────────────────────────────────────────────────────
@@ -152,6 +174,24 @@ describe('WebhookService', () => {
       });
 
       expect(result.url).toBe('https://new.example.com/hook');
+    });
+
+    it('invalidates cache after update', async () => {
+      const updated = { ...mockEndpoint, url: 'https://new.example.com/hook' };
+      mockPrisma.webhookEndpoint.update.mockResolvedValue(updated);
+      mockPrisma.webhookEndpoint.findUnique.mockResolvedValue(updated);
+      const invalidateSpy = jest.spyOn(cache, 'invalidate');
+
+      await service.getEndpoint(ENDPOINT_ID);
+      await service.updateEndpoint(ENDPOINT_ID, {
+        url: 'https://new.example.com/hook',
+      });
+      await service.getEndpoint(ENDPOINT_ID);
+
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        cache.endpointKey(ENDPOINT_ID),
+      );
+      expect(mockPrisma.webhookEndpoint.findUnique).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/webhooks/webhook.service.ts
+++ b/src/webhooks/webhook.service.ts
@@ -2,6 +2,8 @@ import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { WebhookEndpoint, EndpointStatus } from './domain/webhook-events';
 import * as crypto from 'crypto';
+import { logWebhookOperation } from './webhook-logging.util';
+import { WebhookCacheService } from './webhook-cache.service';
 
 export interface CreateWebhookEndpointRequest {
   projectId: string;
@@ -32,7 +34,10 @@ export interface UpdateWebhookEndpointRequest {
 export class WebhookService {
   private readonly logger = new Logger(WebhookService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly webhookCache: WebhookCacheService,
+  ) {}
 
   /**
    * Creates a new webhook endpoint
@@ -40,8 +45,11 @@ export class WebhookService {
   async createEndpoint(
     request: CreateWebhookEndpointRequest,
   ): Promise<WebhookEndpoint> {
-    this.logger.log(
+    logWebhookOperation(
+      this.logger,
+      'log',
       `Creating webhook endpoint for project ${request.projectId}`,
+      { projectId: request.projectId },
     );
 
     // Generate secret for signing
@@ -58,7 +66,12 @@ export class WebhookService {
       },
     });
 
-    this.logger.log(`Created webhook endpoint ${endpoint.id}`);
+    logWebhookOperation(
+      this.logger,
+      'log',
+      `Created webhook endpoint ${endpoint.id}`,
+      { endpointId: endpoint.id, projectId: request.projectId },
+    );
     return this.mapPrismaEndpointToDomain(endpoint);
   }
 
@@ -78,6 +91,12 @@ export class WebhookService {
    * Gets a webhook endpoint by ID
    */
   async getEndpoint(endpointId: string): Promise<WebhookEndpoint> {
+    const cacheKey = this.webhookCache.endpointKey(endpointId);
+    const cached = this.webhookCache.get<WebhookEndpoint>(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
     const endpoint = await this.prisma.webhookEndpoint.findUnique({
       where: { id: endpointId },
     });
@@ -86,7 +105,9 @@ export class WebhookService {
       throw new NotFoundException(`Webhook endpoint ${endpointId} not found`);
     }
 
-    return this.mapPrismaEndpointToDomain(endpoint);
+    const mapped = this.mapPrismaEndpointToDomain(endpoint);
+    this.webhookCache.set(cacheKey, mapped);
+    return mapped;
   }
 
   /**
@@ -101,7 +122,13 @@ export class WebhookService {
       data: updates,
     });
 
-    this.logger.log(`Updated webhook endpoint ${endpointId}`);
+    this.webhookCache.invalidate(this.webhookCache.endpointKey(endpointId));
+    logWebhookOperation(
+      this.logger,
+      'log',
+      `Updated webhook endpoint ${endpointId}`,
+      { endpointId },
+    );
     return this.mapPrismaEndpointToDomain(endpoint);
   }
 
@@ -113,7 +140,13 @@ export class WebhookService {
       where: { id: endpointId },
     });
 
-    this.logger.log(`Deleted webhook endpoint ${endpointId}`);
+    this.webhookCache.invalidate(this.webhookCache.endpointKey(endpointId));
+    logWebhookOperation(
+      this.logger,
+      'log',
+      `Deleted webhook endpoint ${endpointId}`,
+      { endpointId },
+    );
   }
 
   /**
@@ -127,7 +160,13 @@ export class WebhookService {
       data: { secret: newSecret },
     });
 
-    this.logger.log(`Rotated secret for webhook endpoint ${endpointId}`);
+    this.webhookCache.invalidate(this.webhookCache.endpointKey(endpointId));
+    logWebhookOperation(
+      this.logger,
+      'log',
+      `Rotated secret for webhook endpoint ${endpointId}`,
+      { endpointId },
+    );
     return { secret: newSecret };
   }
 

--- a/src/webhooks/webhooks-feature-flag.guard.spec.ts
+++ b/src/webhooks/webhooks-feature-flag.guard.spec.ts
@@ -1,0 +1,49 @@
+import { ForbiddenException } from '@nestjs/common';
+import { ExecutionContext } from '@nestjs/common/interfaces';
+import { FeatureFlagService } from '../common/services/feature-flag.service';
+import {
+  FEATURE_WEBHOOKS_ENABLED,
+  WebhooksFeatureFlagGuard,
+} from './webhooks-feature-flag.guard';
+
+describe('WebhooksFeatureFlagGuard', () => {
+  let guard: WebhooksFeatureFlagGuard;
+  let featureFlagService: jest.Mocked<FeatureFlagService>;
+  const mockContext = {} as ExecutionContext;
+
+  beforeEach(() => {
+    featureFlagService = {
+      isEnabled: jest.fn(),
+    } as unknown as jest.Mocked<FeatureFlagService>;
+    guard = new WebhooksFeatureFlagGuard(featureFlagService);
+  });
+
+  it('allows requests when FEATURE_WEBHOOKS_ENABLED=true', () => {
+    featureFlagService.isEnabled.mockReturnValue(true);
+
+    expect(guard.canActivate(mockContext)).toBe(true);
+    expect(featureFlagService.isEnabled).toHaveBeenCalledWith(
+      FEATURE_WEBHOOKS_ENABLED,
+      false,
+    );
+  });
+
+  it('returns 403 when FEATURE_WEBHOOKS_ENABLED=false', () => {
+    featureFlagService.isEnabled.mockReturnValue(false);
+
+    expect(() => guard.canActivate(mockContext)).toThrow(ForbiddenException);
+    expect(() => guard.canActivate(mockContext)).toThrow(
+      expect.objectContaining({
+        response: { error: 'Webhooks feature is currently disabled' },
+      }),
+    );
+  });
+
+  it('returns 403 when FEATURE_WEBHOOKS_ENABLED is unset', () => {
+    featureFlagService.isEnabled.mockImplementation(
+      (_flag, defaultValue) => defaultValue,
+    );
+
+    expect(() => guard.canActivate(mockContext)).toThrow(ForbiddenException);
+  });
+});

--- a/src/webhooks/webhooks-feature-flag.guard.ts
+++ b/src/webhooks/webhooks-feature-flag.guard.ts
@@ -1,0 +1,23 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { FeatureFlagService } from '../common/services/feature-flag.service';
+
+export const FEATURE_WEBHOOKS_ENABLED = 'FEATURE_WEBHOOKS_ENABLED';
+
+@Injectable()
+export class WebhooksFeatureFlagGuard implements CanActivate {
+  constructor(private readonly featureFlagService: FeatureFlagService) {}
+
+  canActivate(_context: ExecutionContext): boolean {
+    if (!this.featureFlagService.isEnabled(FEATURE_WEBHOOKS_ENABLED, false)) {
+      throw new ForbiddenException({
+        error: 'Webhooks feature is currently disabled',
+      });
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
Summary
This PR adds request ID propagation, subscription caching, and a feature flag guard to the webhooks module, plus integration test coverage for the balance indexer’s event indexing semantics (idempotency, ordering, multi-asset, and DB retry).

Changes
#379 — Webhooks request ID propagation
Extended the existing global requestLogger middleware to set x-request-id on the request/response and run handlers inside RequestContext (AsyncLocalStorage)
Added structured webhook logging helper with requestId in every log entry
WebhookDispatcherService forwards x-request-id on outbound webhook HTTP calls when a request context exists
Unit tests for middleware propagation and dispatcher header forwarding
#380 — Webhooks cache layer stub
Added WebhookCacheService (in-memory Map, 60s TTL, Redis TODO comment)
Wrapped WebhookService.getEndpoint with cache-check-then-fetch; invalidates on update, delete, and secret rotation
Unit tests for cache hit, miss, and invalidation on update
#381 — Webhooks feature flag guard
Added FeatureFlagService reading FEATURE_WEBHOOKS_ENABLED from env
Added WebhooksFeatureFlagGuard on WebhookController returning 403 when disabled
Health endpoints remain unaffected (separate controller)
Unit tests for enabled/disabled/unset flag states
#382 — Balance indexer integration tests
Added indexBalanceEvent with duplicate-event and out-of-order ledger guards
Added balance-indexer.integration.spec.ts following the wallet orchestrator harness pattern
Covers: new balance, update, idempotency, out-of-order events, multiple assets, DB failure + retry
Notes
Request ID middleware was reused from the existing global request-logging.middleware.ts (issue #349 pattern); no duplicate middleware was created
No shared cache from transactions (#350) existed — a fresh WebhookCacheService was created
No shared feature flag guard from transactions (#351) existed — FeatureFlagService and WebhooksFeatureFlagGuard were created fresh
Balance indexer event format inferred from BalanceUpdate; added BalanceChangeEvent with transactionHash for idempotency
Integration tests use an in-memory Prisma stub, matching sibling harness tests rather than a live test DB
Closes #379, Closes #380, Closes #381, Closes #382

