### PR TITLE
feat: add pagination and filtering to the wallet list endpoint

### DIFF
--- a/docs/WALLET-API.md
+++ b/docs/WALLET-API.md
@@ -10,7 +10,7 @@ clients must consume it immediately and must not expect it to be replayed.
 | Method | Route | Behavior |
 | --- | --- | --- |
 | `POST` | `/wallets` | Creates one active wallet per user/network pair. Duplicate user/network requests return `409`. |
-| `GET` | `/wallets` | Lists wallets. |
+| `GET` | `/wallets` | Lists wallets. Supports `userId`, `network`, `status` filters and `limit`/`offset` pagination (default `limit=20`, max `100`). Returns `{ data, total, limit, offset, hasMore }`. |
 | `GET` | `/wallets/:id` | Returns a wallet or `404`. |
 | `GET` | `/wallets/:id/status` | Returns lifecycle status without decrypting the private key. |
 | `PATCH` | `/wallets/:id` | Updates wallet lifecycle status. |

--- a/src/wallets/wallets.controller.spec.ts
+++ b/src/wallets/wallets.controller.spec.ts
@@ -147,6 +147,65 @@ describe('WalletsController', () => {
     });
   });
 
+  // #325 / #326: pagination + filtering on the wallet list endpoint
+  describe('findAll', () => {
+    it('passes filters and default-parsed pagination through to the service', async () => {
+      const page = {
+        data: [{ id: 'wallet-1', userId: 'user-123', network: WalletNetwork.TESTNET }],
+        total: 1,
+        limit: 20,
+        offset: 0,
+        hasMore: false,
+      };
+      mockWalletsService.findAll.mockResolvedValue(page);
+
+      await expect(
+        controller.findAll('user-123', WalletNetwork.TESTNET, undefined, undefined, undefined),
+      ).resolves.toEqual(page);
+      expect(mockWalletsService.findAll).toHaveBeenCalledWith({
+        userId: 'user-123',
+        network: WalletNetwork.TESTNET,
+        status: undefined,
+        limit: undefined,
+        offset: undefined,
+      });
+    });
+
+    it('parses limit and offset query strings into numbers', async () => {
+      mockWalletsService.findAll.mockResolvedValue({
+        data: [],
+        total: 0,
+        limit: 5,
+        offset: 10,
+        hasMore: false,
+      });
+
+      await controller.findAll(undefined, undefined, undefined, '5', '10');
+
+      expect(mockWalletsService.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 5, offset: 10 }),
+      );
+    });
+
+    it('throws a 400 for a non-numeric limit', () => {
+      expect(() =>
+        controller.findAll(undefined, undefined, undefined, 'abc', undefined),
+      ).toThrow('limit must be a non-negative integer');
+    });
+
+    it('throws a 400 when limit exceeds the max', () => {
+      expect(() =>
+        controller.findAll(undefined, undefined, undefined, '1000', undefined),
+      ).toThrow('limit must not exceed 100');
+    });
+
+    it('throws a 400 for a negative offset', () => {
+      expect(() =>
+        controller.findAll(undefined, undefined, undefined, undefined, '-1'),
+      ).toThrow('offset must be a non-negative integer');
+    });
+  });
+
   // #189: List wallets by userId
   describe('findByUserId', () => {
     it('should return wallets for a userId', async () => {

--- a/src/wallets/wallets.controller.ts
+++ b/src/wallets/wallets.controller.ts
@@ -9,8 +9,15 @@ import {
   UseGuards,
   Headers,
   Query,
+  BadRequestException,
 } from '@nestjs/common';
-import { ApiTags, ApiSecurity, ApiOperation, ApiParam } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiSecurity,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
 import {
   WalletCreationOrchestrator,
   type CreateWalletOrchestratorRequest,
@@ -18,11 +25,31 @@ import {
 import { WalletsService } from './wallets.service';
 import { CreateWalletDto } from './dto/create-wallet.dto';
 import { UpdateWalletDto } from './dto/update-wallet.dto';
+import { WalletNetwork, WalletStatus } from './domain/wallet.model';
 import { RequireApiKey } from '../api-keys/decorators/require-api-key.decorator';
 import { ApiKeyCtx } from '../api-keys/decorators/api-key-context.decorator';
 import type { ApiKeyContext } from '../api-keys/domain/api-key.model';
 import { ApiKeyGuard } from '../api-keys/api-key.guard';
 import { RateLimitGuard } from '../rate-limit/rate-limit.guard';
+
+/** Parse a pagination query param, throwing 400 on invalid input */
+function parsePaginationParam(
+  value: string | undefined,
+  name: string,
+  max = 100,
+): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) {
+    throw new BadRequestException(
+      `${name} must be a non-negative integer`,
+    );
+  }
+  if (name === 'limit' && n > max) {
+    throw new BadRequestException(`limit must not exceed ${max}`);
+  }
+  return n;
+}
 
 @ApiTags('wallets')
 @ApiSecurity('api-key')
@@ -49,10 +76,27 @@ export class WalletsController {
     return this.walletCreationOrchestrator.createWallet(createRequest, requestId);
   }
 
-  @ApiOperation({ summary: 'List all wallets' })
+  @ApiOperation({ summary: 'List wallets with optional filters and pagination' })
+  @ApiQuery({ name: 'userId', required: false, description: 'Filter by owning user ID' })
+  @ApiQuery({ name: 'network', required: false, enum: WalletNetwork, description: 'Filter by network' })
+  @ApiQuery({ name: 'status', required: false, enum: WalletStatus, description: 'Filter by wallet status' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Max records to return (1-100, default 20)', example: 20 })
+  @ApiQuery({ name: 'offset', required: false, description: 'Number of records to skip (default 0)', example: 0 })
   @Get()
-  findAll() {
-    return this.walletsService.findAll();
+  findAll(
+    @Query('userId') userId?: string,
+    @Query('network') network?: WalletNetwork,
+    @Query('status') status?: WalletStatus,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
+    return this.walletsService.findAll({
+      userId,
+      network,
+      status,
+      limit: parsePaginationParam(limit, 'limit'),
+      offset: parsePaginationParam(offset, 'offset'),
+    });
   }
 
   @RequireApiKey()

--- a/src/wallets/wallets.service.spec.ts
+++ b/src/wallets/wallets.service.spec.ts
@@ -21,6 +21,7 @@ const mockPrismaWallet = {
   update: jest.fn(),
   delete: jest.fn(),
   findMany: jest.fn(),
+  count: jest.fn(),
 };
 
 // Mock the PrismaClient module so new PrismaClient() returns our mock
@@ -628,6 +629,99 @@ describe('WalletsService', () => {
       const result = await service.findWalletsByUserId('user-no-wallets');
 
       expect(result).toEqual([]);
+    });
+  });
+
+  // #325 / #326: pagination + filtering on the wallet list endpoint
+  describe('findAll', () => {
+    const walletRow = {
+      id: 'wallet-1',
+      userId: 'user-123',
+      publicKey: 'GABC1',
+      encryptedSecret: 'secret1',
+      encryptionVersion: 1,
+      secretVersion: 1,
+      network: WalletNetwork.TESTNET,
+      status: 'ACTIVE',
+      statusReason: null,
+      statusChangedAt: new Date(),
+      rotatedFromId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('defaults to limit=20 and offset=0 with no filters', async () => {
+      mockPrismaWallet.findMany.mockResolvedValue([walletRow]);
+      mockPrismaWallet.count.mockResolvedValue(1);
+
+      const result = await service.findAll();
+
+      expect(mockPrismaWallet.findMany).toHaveBeenCalledWith({
+        where: {},
+        orderBy: { createdAt: 'desc' },
+        take: 20,
+        skip: 0,
+      });
+      expect(mockPrismaWallet.count).toHaveBeenCalledWith({ where: {} });
+      expect(result).toEqual({
+        data: [expect.objectContaining({ id: 'wallet-1' })],
+        total: 1,
+        limit: 20,
+        offset: 0,
+        hasMore: false,
+      });
+    });
+
+    it('applies network, status, and userId filters', async () => {
+      mockPrismaWallet.findMany.mockResolvedValue([]);
+      mockPrismaWallet.count.mockResolvedValue(0);
+
+      await service.findAll({
+        userId: 'user-123',
+        network: WalletNetwork.MAINNET,
+        status: WalletStatus.ACTIVE,
+      });
+
+      expect(mockPrismaWallet.findMany).toHaveBeenCalledWith({
+        where: {
+          userId: 'user-123',
+          network: WalletNetwork.MAINNET,
+          status: WalletStatus.ACTIVE,
+        },
+        orderBy: { createdAt: 'desc' },
+        take: 20,
+        skip: 0,
+      });
+    });
+
+    it('passes a custom limit and offset through to Prisma', async () => {
+      mockPrismaWallet.findMany.mockResolvedValue([]);
+      mockPrismaWallet.count.mockResolvedValue(0);
+
+      await service.findAll({ limit: 5, offset: 10 });
+
+      expect(mockPrismaWallet.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 5, skip: 10 }),
+      );
+    });
+
+    it('sets hasMore=true when more records remain after this page', async () => {
+      mockPrismaWallet.findMany.mockResolvedValue([walletRow]);
+      mockPrismaWallet.count.mockResolvedValue(5);
+
+      const result = await service.findAll({ limit: 1, offset: 0 });
+
+      expect(result.hasMore).toBe(true);
+      expect(result.total).toBe(5);
+    });
+
+    it('sets hasMore=false on the last page', async () => {
+      mockPrismaWallet.findMany.mockResolvedValue([walletRow]);
+      mockPrismaWallet.count.mockResolvedValue(5);
+
+      const result = await service.findAll({ limit: 20, offset: 4 });
+
+      expect(result.hasMore).toBe(false);
     });
   });
 });

--- a/src/wallets/wallets.service.ts
+++ b/src/wallets/wallets.service.ts
@@ -30,6 +30,22 @@ export interface CreateWalletRequest {
   network: WalletNetwork;
 }
 
+export interface WalletListFilters {
+  userId?: string;
+  network?: WalletNetwork;
+  status?: WalletStatus;
+  limit?: number;
+  offset?: number;
+}
+
+export interface WalletListResult {
+  data: Wallet[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
 export interface WalletCreationResult {
   wallet: Wallet;
   privateKey: string;
@@ -275,8 +291,42 @@ export class WalletsService {
     return wallets.map((wallet) => this.mapPrismaWalletToDomain(wallet));
   }
 
+  async findAll(filters?: WalletListFilters): Promise<WalletListResult> {
+    const where: Record<string, unknown> = {};
+
+    if (filters?.userId) {
+      where.userId = filters.userId;
+    }
+    if (filters?.network) {
+      where.network = filters.network;
+    }
+    if (filters?.status) {
+      where.status = filters.status;
+    }
+
+    const limit = filters?.limit ?? 20;
+    const offset = filters?.offset ?? 0;
+
+    const [wallets, total] = await Promise.all([
+      this.prisma.wallet.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+        skip: offset,
+      }),
+      this.prisma.wallet.count({ where }),
+    ]);
+
+    return {
+      data: wallets.map((wallet) => this.mapPrismaWalletToDomain(wallet)),
+      total,
+      limit,
+      offset,
+      hasMore: offset + wallets.length < total,
+    };
+  }
+
   create(createWalletDto: any) { return this.createWallet(createWalletDto); }
-  findAll() { return this.prisma.wallet.findMany(); }
   findOne(id: string) { return this.findWalletById(id); }
   update(id: string, updateWalletDto: any) { return this.updateWalletStatus(id, updateWalletDto.status); }
   remove(id: string) { return this.prisma.wallet.delete({ where: { id } }); }


### PR DESCRIPTION
## Summary
- `GET /wallets` previously called `prisma.wallet.findMany()` with no arguments, returning every wallet row unbounded and with no way to narrow results.
- Adds `userId`, `network`, and `status` filter query params (#326).
- Adds `limit`/`offset` pagination, default `limit=20`, max `100`, validated the same way the transactions list endpoint does (#325).
- Response shape is now `{ data, total, limit, offset, hasMore }`.
- Updated `docs/WALLET-API.md` to reflect the new query params and response shape.

Implemented together since both issues land on the exact same controller method and service method.

## Test plan
- `WalletsService.findAll`: default pagination, network/status/userId filters, custom limit/offset, `hasMore` true/false at page boundaries.
- `WalletsController.findAll`: filters + pagination passed through to the service, and `400` for non-numeric limit, limit over max, and negative offset.
- `npx jest wallets.service.spec.ts wallets.controller.spec.ts`

Closes #325
Closes #326
closes #323 
closes #324 