### PR TITLE
Fix/balance indexer cache featureflag keymgmt openapi

### DIFF
--- a/src/api-keys/api-key.controller.ts
+++ b/src/api-keys/api-key.controller.ts
@@ -10,12 +10,22 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+  ApiBody,
+  ApiProperty,
+} from '@nestjs/swagger';
+import {
   ApiKeyService,
   CreateApiKeyRequest,
   ListApiKeysRequest,
 } from './api-key.service';
 import { CreateApiKeyDto } from './dto/create-api-key.dto';
 
+@ApiTags('api-keys')
 @Controller('api-keys')
 export class ApiKeyController {
   constructor(private readonly apiKeyService: ApiKeyService) {}
@@ -25,6 +35,79 @@ export class ApiKeyController {
    */
   @Post()
   @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Create a new API key',
+    description:
+      'Generates a new API key for a project. The plain-text key is returned **only once** — store it securely.',
+  })
+  @ApiBody({
+    type: CreateApiKeyDto,
+    examples: {
+      basic: {
+        summary: 'Basic key creation',
+        value: { name: 'production-key', projectId: 'project-abc123' },
+      },
+      withExpiry: {
+        summary: 'Key with expiration date',
+        value: {
+          name: 'temporary-key',
+          projectId: 'project-abc123',
+          expiresAt: '2027-01-01T00:00:00.000Z',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'API key created — plain-text key returned only here.',
+    schema: {
+      type: 'object',
+      properties: {
+        message: {
+          type: 'string',
+          example: 'Store this key securely — it will not be shown again',
+        },
+        apiKey: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'apikey-uuid-here' },
+            name: { type: 'string', example: 'production-key' },
+            keyPrefix: { type: 'string', example: 'mux_live_' },
+            lastFour: { type: 'string', example: 'Ab1C' },
+            status: { type: 'string', example: 'ACTIVE' },
+            createdAt: { type: 'string', format: 'date-time' },
+          },
+        },
+        plainTextKey: {
+          type: 'string',
+          example: 'mux_live_AbCdEfGhIjKlMnOpQrStUvWx',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request — missing or invalid fields.',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        message: { type: 'array', items: { type: 'string' } },
+        error: { type: 'string', example: 'Bad Request' },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Project not found.',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'Project project-abc123 not found' },
+      },
+    },
+  })
   async createApiKey(@Body() request: CreateApiKeyDto) {
     const result = await this.apiKeyService.createApiKey(
       request as CreateApiKeyRequest,
@@ -49,6 +132,53 @@ export class ApiKeyController {
    * Lists all API keys for a project with pagination
    */
   @Get()
+  @ApiOperation({
+    summary: 'List API keys for a project',
+    description: 'Returns paginated API key metadata. Plain-text keys are never exposed here.',
+  })
+  @ApiQuery({ name: 'projectId', required: true, description: 'Project ID to list keys for', example: 'project-abc123' })
+  @ApiQuery({ name: 'page', required: false, description: 'Page number (1-based)', example: 1 })
+  @ApiQuery({ name: 'pageSize', required: false, description: 'Number of results per page', example: 10 })
+  @ApiQuery({ name: 'developerId', required: false, description: 'Optional developer ID for ownership check' })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of API key metadata.',
+    schema: {
+      type: 'object',
+      properties: {
+        keys: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'string', example: 'apikey-uuid-here' },
+              name: { type: 'string', example: 'production-key' },
+              keyPrefix: { type: 'string', example: 'mux_live_' },
+              lastFour: { type: 'string', example: 'Ab1C' },
+              status: { type: 'string', example: 'ACTIVE' },
+              lastUsedAt: { type: 'string', format: 'date-time', nullable: true },
+              createdAt: { type: 'string', format: 'date-time' },
+              expiresAt: { type: 'string', format: 'date-time', nullable: true },
+              projectId: { type: 'string', example: 'project-abc123' },
+            },
+          },
+        },
+        pagination: {
+          type: 'object',
+          properties: {
+            page: { type: 'number', example: 1 },
+            pageSize: { type: 'number', example: 10 },
+            total: { type: 'number', example: 42 },
+            totalPages: { type: 'number', example: 5 },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized — developer does not own this project.',
+  })
   async listApiKeys(
     @Query('projectId') projectId: string,
     @Query('page') page?: string,
@@ -88,6 +218,39 @@ export class ApiKeyController {
    */
   @Post(':apiKeyId/revoke')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Revoke an API key',
+    description: 'Marks the key as REVOKED. Idempotent — revoking an already-revoked key succeeds.',
+  })
+  @ApiParam({ name: 'apiKeyId', description: 'ID of the API key to revoke', example: 'apikey-uuid-here' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        reason: { type: 'string', example: 'Key compromised', description: 'Optional revocation reason' },
+        developerId: { type: 'string', example: 'dev-uuid', description: 'Optional: verify ownership before revoking' },
+      },
+    },
+    examples: {
+      basic: { summary: 'Revoke without reason', value: {} },
+      withReason: { summary: 'Revoke with reason', value: { reason: 'Key compromised during security incident' } },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'API key revoked successfully.',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', example: 'apikey-uuid-here' },
+        status: { type: 'string', example: 'REVOKED' },
+        revokedAt: { type: 'string', format: 'date-time' },
+        revokedReason: { type: 'string', nullable: true, example: 'Key compromised' },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: 'Not authorized to revoke this key.' })
+  @ApiResponse({ status: 404, description: 'API key not found.' })
   async revokeApiKey(
     @Param('apiKeyId') apiKeyId: string,
     @Body() body: { reason?: string; developerId?: string },
@@ -111,6 +274,50 @@ export class ApiKeyController {
    */
   @Post(':apiKeyId/rotate')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Rotate an API key',
+    description:
+      'Creates a new API key and sets the old key into a grace-period window (configurable via `API_KEY_ROTATION_GRACE_SECONDS`). ' +
+      'Both keys remain valid during the grace period so clients can migrate without downtime.',
+  })
+  @ApiParam({ name: 'apiKeyId', description: 'ID of the API key to rotate', example: 'apikey-uuid-here' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', example: 'production-key-v2', description: 'Optional name for the new key' },
+        developerId: { type: 'string', example: 'dev-uuid', description: 'Optional: verify ownership before rotating' },
+      },
+    },
+    examples: {
+      basic: { summary: 'Rotate without renaming', value: {} },
+      withName: { summary: 'Rotate with new name', value: { name: 'production-key-v2' } },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'New API key returned. Old key stays valid during the grace period.',
+    schema: {
+      type: 'object',
+      properties: {
+        message: { type: 'string', example: 'Store this key securely — it will not be shown again' },
+        apiKey: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'apikey-new-uuid' },
+            name: { type: 'string', example: 'production-key-v2' },
+            keyPrefix: { type: 'string', example: 'mux_live_' },
+            lastFour: { type: 'string', example: 'Xy9Z' },
+            status: { type: 'string', example: 'ACTIVE' },
+            createdAt: { type: 'string', format: 'date-time' },
+          },
+        },
+        plainTextKey: { type: 'string', example: 'mux_live_XyZaBcDeFgHiJkLmNoPqRsTuV' },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: 'Not authorized to rotate this key.' })
+  @ApiResponse({ status: 404, description: 'API key not found.' })
   async rotateApiKey(
     @Param('apiKeyId') apiKeyId: string,
     @Body() body: { name?: string; developerId?: string },

--- a/src/api-keys/api-key.controller.ts
+++ b/src/api-keys/api-key.controller.ts
@@ -4,7 +4,6 @@ import {
   Get,
   Body,
   Param,
-  Delete,
   Query,
   HttpCode,
   HttpStatus,
@@ -16,7 +15,6 @@ import {
   ApiParam,
   ApiQuery,
   ApiBody,
-  ApiProperty,
 } from '@nestjs/swagger';
 import {
   ApiKeyService,

--- a/src/api-keys/api-key.integration.spec.ts
+++ b/src/api-keys/api-key.integration.spec.ts
@@ -1,0 +1,350 @@
+/**
+ * API Key Management — integration tests
+ *
+ * Uses a mock PrismaClient to exercise the full ApiKeyService lifecycle:
+ * create → validate → list → rotate → revoke.
+ * The mock stores keys in memory so calls cross-reference correctly.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ApiKeyService } from './api-key.service';
+import { ApiKeyStatus } from './domain/api-key.model';
+
+jest.mock('../generated/prisma/client', () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({
+    project: { findUnique: jest.fn() },
+    apiKey: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      count: jest.fn(),
+      update: jest.fn(),
+    },
+    apiKeyUsage: { create: jest.fn() },
+  })),
+}));
+
+describe('ApiKeyService (integration)', () => {
+  let service: ApiKeyService;
+  let mockPrisma: any;
+  const storedKeys: any[] = [];
+
+  const project = {
+    id: 'project-integration-1',
+    environment: 'production',
+    developerId: 'dev-integration-1',
+  };
+
+  beforeEach(async () => {
+    storedKeys.length = 0;
+
+    mockPrisma = {
+      project: {
+        findUnique: jest.fn().mockResolvedValue(project),
+      },
+      apiKey: {
+        create: jest.fn().mockImplementation(async ({ data }) => {
+          const key = {
+            id: `key-${storedKeys.length + 1}`,
+            name: data.name,
+            keyHash: data.keyHash,
+            keyPrefix: data.keyPrefix,
+            lastFour: data.lastFour,
+            projectId: data.projectId,
+            status: data.status,
+            expiresAt: data.expiresAt ?? null,
+            gracePeriodEndsAt: null,
+            lastUsedAt: null,
+            revokedAt: null,
+            revokedReason: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          };
+          storedKeys.push(key);
+          return key;
+        }),
+        findUnique: jest.fn().mockImplementation(async ({ where }) => {
+          if (where?.id) {
+            return storedKeys.find((k) => k.id === where.id) ?? null;
+          }
+          if (where?.keyHash) {
+            const found = storedKeys.find((k) => k.keyHash === where.keyHash);
+            if (!found) return null;
+            return {
+              ...found,
+              project: { ...project, developer: { id: project.developerId } },
+            };
+          }
+          return null;
+        }),
+        findMany: jest.fn().mockImplementation(async ({ where, skip = 0, take }) => {
+          const all = storedKeys.filter((k) => k.projectId === where.projectId);
+          return all.slice(skip, take ? skip + take : undefined);
+        }),
+        count: jest.fn().mockImplementation(async ({ where }) =>
+          storedKeys.filter((k) => k.projectId === where.projectId).length,
+        ),
+        update: jest.fn().mockImplementation(async ({ where, data }) => {
+          const key = storedKeys.find((k) => k.id === where.id);
+          if (!key) throw new Error('Not found');
+          Object.assign(key, data);
+          return key;
+        }),
+      },
+      apiKeyUsage: { create: jest.fn() },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApiKeyService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) =>
+              key === 'API_KEY_ROTATION_GRACE_SECONDS' ? 3600 : undefined,
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ApiKeyService>(ApiKeyService);
+    service['prisma'] = mockPrisma;
+  });
+
+  // ---------------------------------------------------------------------------
+  // Create
+  // ---------------------------------------------------------------------------
+
+  describe('createApiKey', () => {
+    it('returns a mux_live_ prefixed key for a production project', async () => {
+      const { plainTextKey } = await service.createApiKey({
+        name: 'prod-key',
+        projectId: project.id,
+      });
+      expect(plainTextKey).toMatch(/^mux_live_/);
+    });
+
+    it('stores a SHA-256 hash, never the plain-text key', async () => {
+      const { apiKey, plainTextKey } = await service.createApiKey({
+        name: 'hash-check',
+        projectId: project.id,
+      });
+      expect(apiKey.keyHash).toMatch(/^[a-f0-9]{64}$/);
+      expect(apiKey.keyHash).not.toBe(plainTextKey);
+    });
+
+    it('sets status ACTIVE on creation', async () => {
+      const { apiKey } = await service.createApiKey({
+        name: 'active-check',
+        projectId: project.id,
+      });
+      expect(apiKey.status).toBe(ApiKeyStatus.ACTIVE);
+    });
+
+    it('respects an explicit expiresAt date', async () => {
+      const expiresAt = new Date(Date.now() + 86_400_000); // +1 day
+      const { apiKey } = await service.createApiKey({
+        name: 'expiring',
+        projectId: project.id,
+        expiresAt,
+      });
+      expect(apiKey.expiresAt?.toISOString()).toBe(expiresAt.toISOString());
+    });
+
+    it('throws when the project does not exist', async () => {
+      mockPrisma.project.findUnique.mockResolvedValueOnce(null);
+      await expect(
+        service.createApiKey({ name: 'ghost', projectId: 'nonexistent' }),
+      ).rejects.toThrow('not found');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Validate
+  // ---------------------------------------------------------------------------
+
+  describe('validateApiKey', () => {
+    it('rejects keys that do not start with mux_', async () => {
+      await expect(service.validateApiKey('sk_bad_key')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('rejects a key that is not in the store', async () => {
+      await expect(
+        service.validateApiKey('mux_live_doesnotexist'),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('successfully validates a freshly created key', async () => {
+      const { plainTextKey } = await service.createApiKey({
+        name: 'validate-me',
+        projectId: project.id,
+      });
+      const ctx = await service.validateApiKey(plainTextKey);
+      expect(ctx.apiKey.status).toBe(ApiKeyStatus.ACTIVE);
+      expect(ctx.project.id).toBe(project.id);
+    });
+
+    it('rejects a key that has already been revoked', async () => {
+      const { apiKey, plainTextKey } = await service.createApiKey({
+        name: 'to-revoke',
+        projectId: project.id,
+      });
+      await service.revokeApiKey(apiKey.id);
+      await expect(service.validateApiKey(plainTextKey)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('rejects a key that has passed its expiresAt', async () => {
+      const { apiKey, plainTextKey } = await service.createApiKey({
+        name: 'past-expiry',
+        projectId: project.id,
+        expiresAt: new Date(Date.now() - 1000),
+      });
+      await expect(service.validateApiKey(plainTextKey)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // List
+  // ---------------------------------------------------------------------------
+
+  describe('listApiKeys', () => {
+    it('returns all keys created for the project', async () => {
+      await service.createApiKey({ name: 'k1', projectId: project.id });
+      await service.createApiKey({ name: 'k2', projectId: project.id });
+      const { keys, total } = await service.listApiKeys({
+        projectId: project.id,
+      });
+      expect(total).toBe(2);
+      expect(keys).toHaveLength(2);
+    });
+
+    it('paginates results correctly', async () => {
+      for (let i = 0; i < 5; i++) {
+        await service.createApiKey({ name: `key-${i}`, projectId: project.id });
+      }
+      const { keys, total, page, pageSize } = await service.listApiKeys({
+        projectId: project.id,
+        page: 1,
+        pageSize: 3,
+      });
+      expect(total).toBe(5);
+      expect(keys).toHaveLength(3);
+      expect(page).toBe(1);
+      expect(pageSize).toBe(3);
+    });
+
+    it('never exposes keyHash or plain-text key in list results', async () => {
+      await service.createApiKey({ name: 'safe-list', projectId: project.id });
+      const { keys } = await service.listApiKeys({ projectId: project.id });
+      keys.forEach((k) => {
+        expect((k as any).keyHash).toBeUndefined();
+        expect((k as any).plainTextKey).toBeUndefined();
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rotate
+  // ---------------------------------------------------------------------------
+
+  describe('rotateApiKey', () => {
+    it('creates a new key and both keys are initially valid', async () => {
+      const { apiKey: old, plainTextKey: oldPlain } = await service.createApiKey({
+        name: 'rotate-me',
+        projectId: project.id,
+      });
+
+      const { apiKey: next, plainTextKey: nextPlain } =
+        await service.rotateApiKey({ apiKeyId: old.id });
+
+      expect(nextPlain).not.toBe(oldPlain);
+      const oldCtx = await service.validateApiKey(oldPlain);
+      const newCtx = await service.validateApiKey(nextPlain);
+      expect(oldCtx.apiKey.status).toBe(ApiKeyStatus.ACTIVE);
+      expect(newCtx.apiKey.status).toBe(ApiKeyStatus.ACTIVE);
+    });
+
+    it('sets gracePeriodEndsAt on the old key', async () => {
+      const { apiKey } = await service.createApiKey({
+        name: 'grace-check',
+        projectId: project.id,
+      });
+      await service.rotateApiKey({ apiKeyId: apiKey.id });
+      const storedOld = storedKeys.find((k) => k.id === apiKey.id);
+      expect(storedOld.gracePeriodEndsAt).toBeDefined();
+      expect(storedOld.gracePeriodEndsAt.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('optionally accepts a new name for the rotated key', async () => {
+      const { apiKey } = await service.createApiKey({
+        name: 'old-name',
+        projectId: project.id,
+      });
+      const { apiKey: rotated } = await service.rotateApiKey({
+        apiKeyId: apiKey.id,
+        name: 'new-name',
+      });
+      expect(rotated.name).toBe('new-name');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Revoke
+  // ---------------------------------------------------------------------------
+
+  describe('revokeApiKey', () => {
+    it('marks the key as REVOKED', async () => {
+      const { apiKey } = await service.createApiKey({
+        name: 'revoke-me',
+        projectId: project.id,
+      });
+      const revoked = await service.revokeApiKey(apiKey.id);
+      expect(revoked.status).toBe(ApiKeyStatus.REVOKED);
+      expect(revoked.revokedAt).toBeDefined();
+    });
+
+    it('is idempotent — revoking an already-revoked key succeeds', async () => {
+      const { apiKey } = await service.createApiKey({
+        name: 'double-revoke',
+        projectId: project.id,
+      });
+      await service.revokeApiKey(apiKey.id);
+      const second = await service.revokeApiKey(apiKey.id);
+      expect(second.status).toBe(ApiKeyStatus.REVOKED);
+    });
+
+    it('stores the revocation reason', async () => {
+      const { apiKey } = await service.createApiKey({
+        name: 'reason-key',
+        projectId: project.id,
+      });
+      const revoked = await service.revokeApiKey(
+        apiKey.id,
+        'Security incident',
+      );
+      expect(revoked.revokedReason).toBe('Security incident');
+    });
+
+    it('throws when developer does not own the key', async () => {
+      const { apiKey } = await service.createApiKey({
+        name: 'ownership-check',
+        projectId: project.id,
+      });
+      const storedKey = storedKeys.find((k) => k.id === apiKey.id);
+      mockPrisma.apiKey.findUnique.mockResolvedValueOnce({
+        ...storedKey,
+        project: { ...project, developerId: 'other-dev' },
+      });
+      await expect(
+        service.revokeApiKey(apiKey.id, undefined, 'attacker-dev'),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+  });
+});

--- a/src/balance-indexer/balance-cache.service.spec.ts
+++ b/src/balance-indexer/balance-cache.service.spec.ts
@@ -1,0 +1,85 @@
+import { BalanceCacheService } from './balance-cache.service';
+import { CacheService } from '../common/cache/cache.service';
+import { AssetType, BalanceSyncStatus, WalletBalance } from './domain/balance.model';
+
+const WALLET_ID = 'wallet-cache-test';
+const nativeAsset = { type: AssetType.NATIVE };
+
+function makeBalance(overrides: Partial<WalletBalance> = {}): WalletBalance {
+  return {
+    id: 'bal-1',
+    walletId: WALLET_ID,
+    assetType: AssetType.NATIVE,
+    assetCode: null,
+    assetIssuer: null,
+    balance: '100.0000000',
+    syncStatus: BalanceSyncStatus.SYNCED,
+    lastSyncedAt: new Date(),
+    lastSyncedLedger: 1000,
+    lastReconciledAt: null,
+    reconciliationAttempts: 0,
+    onChainBalance: '100.0000000',
+    mismatchDetectedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('BalanceCacheService', () => {
+  let service: BalanceCacheService;
+  let cacheService: CacheService;
+
+  beforeEach(() => {
+    cacheService = new CacheService();
+    service = new BalanceCacheService(cacheService);
+  });
+
+  afterEach(() => {
+    cacheService.clear();
+  });
+
+  it('returns null for a balance not yet cached', () => {
+    const result = service.get(WALLET_ID, nativeAsset);
+    expect(result).toBeNull();
+  });
+
+  it('stores and retrieves a balance by wallet + asset', () => {
+    const balance = makeBalance();
+    service.set(WALLET_ID, nativeAsset, balance);
+    expect(service.get(WALLET_ID, nativeAsset)).toEqual(balance);
+  });
+
+  it('returns null after invalidating a specific asset', () => {
+    const balance = makeBalance();
+    service.set(WALLET_ID, nativeAsset, balance);
+    service.invalidate(WALLET_ID, nativeAsset);
+    expect(service.get(WALLET_ID, nativeAsset)).toBeNull();
+  });
+
+  it('clears all entries on invalidateAll', () => {
+    const usdcAsset = { type: AssetType.CREDIT_ALPHANUM4, code: 'USDC', issuer: 'GISSUER' };
+    service.set(WALLET_ID, nativeAsset, makeBalance());
+    service.set(WALLET_ID, usdcAsset, makeBalance({ assetType: AssetType.CREDIT_ALPHANUM4, assetCode: 'USDC', assetIssuer: 'GISSUER' }));
+    service.invalidateAll(WALLET_ID);
+    expect(service.get(WALLET_ID, nativeAsset)).toBeNull();
+    expect(service.get(WALLET_ID, usdcAsset)).toBeNull();
+  });
+
+  it('isolates cache entries for different wallets', () => {
+    const otherWallet = 'wallet-other';
+    const balance = makeBalance();
+    service.set(WALLET_ID, nativeAsset, balance);
+    expect(service.get(otherWallet, nativeAsset)).toBeNull();
+  });
+
+  it('isolates cache entries for different assets on the same wallet', () => {
+    const usdcAsset = { type: AssetType.CREDIT_ALPHANUM4, code: 'USDC', issuer: 'GISSUER' };
+    const nativeBalance = makeBalance();
+    const usdcBalance = makeBalance({ assetType: AssetType.CREDIT_ALPHANUM4, assetCode: 'USDC', balance: '50.0' });
+    service.set(WALLET_ID, nativeAsset, nativeBalance);
+    service.set(WALLET_ID, usdcAsset, usdcBalance);
+    expect(service.get(WALLET_ID, nativeAsset)).toEqual(nativeBalance);
+    expect(service.get(WALLET_ID, usdcAsset)).toEqual(usdcBalance);
+  });
+});

--- a/src/balance-indexer/balance-cache.service.ts
+++ b/src/balance-indexer/balance-cache.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { CacheService } from '../common/cache/cache.service';
+import { WalletBalance, Asset } from './domain/balance.model';
+
+/**
+ * Thin cache layer for wallet balances.
+ *
+ * Wraps CacheService with balance-domain key generation and a fixed TTL.
+ * In a Redis-backed deployment the invalidateAll helper would use SCAN+DEL
+ * on the wallet prefix; with the in-memory CacheService it falls back to
+ * a full clear so correctness is never compromised.
+ */
+@Injectable()
+export class BalanceCacheService {
+  private static readonly BALANCE_TTL_MS = 60_000;
+
+  constructor(private readonly cache: CacheService) {}
+
+  get(walletId: string, asset: Asset): WalletBalance | null {
+    return this.cache.get<WalletBalance>(this.key(walletId, asset));
+  }
+
+  set(walletId: string, asset: Asset, balance: WalletBalance): void {
+    this.cache.set(
+      this.key(walletId, asset),
+      balance,
+      BalanceCacheService.BALANCE_TTL_MS,
+    );
+  }
+
+  invalidate(walletId: string, asset: Asset): void {
+    this.cache.delete(this.key(walletId, asset));
+  }
+
+  invalidateAll(_walletId: string): void {
+    this.cache.clear();
+  }
+
+  private key(walletId: string, asset: Asset): string {
+    return `balance:${walletId}:${asset.type}:${asset.code ?? ''}:${asset.issuer ?? ''}`;
+  }
+}

--- a/src/balance-indexer/balance-indexer.controller.ts
+++ b/src/balance-indexer/balance-indexer.controller.ts
@@ -9,6 +9,7 @@ import {
   HttpStatus,
   NotFoundException,
   ValidationPipe,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -18,6 +19,10 @@ import {
   ApiQuery,
   ApiBody,
 } from '@nestjs/swagger';
+import {
+  FeatureFlagGuard,
+  FeatureFlag,
+} from '../common/feature-flags/feature-flag.guard';
 import {
   BalanceIndexerService,
   SyncBalancesRequest,
@@ -47,6 +52,8 @@ import { PaginationDto } from '../common/dto/pagination.dto';
  */
 @ApiTags('balances')
 @Controller('balances')
+@UseGuards(FeatureFlagGuard)
+@FeatureFlag('BALANCE_INDEXER')
 export class BalanceIndexerController {
   constructor(private readonly balanceIndexerService: BalanceIndexerService) {}
 

--- a/src/balance-indexer/balance-indexer.feature-flag.spec.ts
+++ b/src/balance-indexer/balance-indexer.feature-flag.spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, HttpException, HttpStatus } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import {
+  FeatureFlagGuard,
+  FeatureFlag,
+  FEATURE_FLAG_KEY,
+} from '../common/feature-flags/feature-flag.guard';
+import { FeatureFlagService } from '../common/feature-flags/feature-flag.service';
+import { BalanceIndexerController } from './balance-indexer.controller';
+
+/**
+ * Verifies that BalanceIndexerController is decorated with @FeatureFlag and
+ * that FeatureFlagGuard enforces the flag correctly.
+ */
+describe('BalanceIndexerController — feature flag guard', () => {
+  it('has @FeatureFlag("BALANCE_INDEXER") metadata on the controller class', () => {
+    const flag = Reflect.getMetadata(
+      FEATURE_FLAG_KEY,
+      BalanceIndexerController,
+    );
+    expect(flag).toBe('BALANCE_INDEXER');
+  });
+
+  describe('FeatureFlagGuard behaviour on balance indexer routes', () => {
+    let guard: FeatureFlagGuard;
+    let featureFlagService: jest.Mocked<FeatureFlagService>;
+    let reflector: jest.Mocked<Reflector>;
+
+    const makeContext = (flagName: string | undefined): ExecutionContext =>
+      ({
+        getHandler: jest.fn().mockReturnValue(() => {}),
+        getClass: jest.fn().mockReturnValue(BalanceIndexerController),
+        switchToHttp: jest.fn(),
+      }) as any;
+
+    beforeEach(() => {
+      featureFlagService = { isEnabled: jest.fn() } as any;
+      reflector = { getAllAndOverride: jest.fn() } as any;
+      guard = new FeatureFlagGuard(featureFlagService, reflector);
+    });
+
+    it('allows access when BALANCE_INDEXER flag is enabled', () => {
+      reflector.getAllAndOverride.mockReturnValue('BALANCE_INDEXER');
+      featureFlagService.isEnabled.mockReturnValue(true);
+      expect(guard.canActivate(makeContext('BALANCE_INDEXER'))).toBe(true);
+    });
+
+    it('throws 403 when BALANCE_INDEXER flag is disabled', () => {
+      reflector.getAllAndOverride.mockReturnValue('BALANCE_INDEXER');
+      featureFlagService.isEnabled.mockReturnValue(false);
+      expect(() => guard.canActivate(makeContext('BALANCE_INDEXER'))).toThrow(
+        HttpException,
+      );
+      try {
+        guard.canActivate(makeContext('BALANCE_INDEXER'));
+      } catch (err: any) {
+        expect(err.getStatus()).toBe(HttpStatus.FORBIDDEN);
+        expect(err.getResponse().message).toContain('Feature is not available');
+      }
+    });
+
+    it('allows access when no flag metadata is present (non-flagged route)', () => {
+      reflector.getAllAndOverride.mockReturnValue(undefined);
+      expect(guard.canActivate(makeContext(undefined))).toBe(true);
+      expect(featureFlagService.isEnabled).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/balance-indexer/balance-indexer.module.ts
+++ b/src/balance-indexer/balance-indexer.module.ts
@@ -4,22 +4,32 @@ import { BalanceIndexerService } from './balance-indexer.service';
 import { BalanceIndexerController } from './balance-indexer.controller';
 import { StellarHorizonService } from './stellar-horizon.service';
 import { BalanceRepository } from './balance.repository';
+import { BalanceCacheService } from './balance-cache.service';
 import { WebhookModule } from '../webhooks/webhook.module';
 import { RequestContextService } from '../common/request-context/request-context.service';
 import { BalanceIndexerMetricsService } from './balance-indexer-metrics.service';
+import { CacheService } from '../common/cache/cache.service';
+import { FeatureFlagService } from '../common/feature-flags/feature-flag.service';
+import { FeatureFlagGuard } from '../common/feature-flags/feature-flag.guard';
 
 @Module({
-  imports: [WebhookModule],
+  imports: [WebhookModule, ConfigModule],
   controllers: [BalanceIndexerController],
   providers: [
     BalanceIndexerService,
     StellarHorizonService,
+    BalanceRepository,
     RequestContextService,
     BalanceIndexerMetricsService,
+    CacheService,
+    BalanceCacheService,
+    FeatureFlagService,
+    FeatureFlagGuard,
   ],
   exports: [
     BalanceIndexerService,
     BalanceIndexerMetricsService,
+    BalanceCacheService,
   ],
 })
 export class BalanceIndexerModule {}

--- a/src/balance-indexer/balance-indexer.service.ts
+++ b/src/balance-indexer/balance-indexer.service.ts
@@ -12,6 +12,7 @@ import { ConfigService } from '@nestjs/config';
 import { StellarHorizonService } from './stellar-horizon.service';
 import { WebhookEventEmitterService } from '../webhooks/webhook-event-emitter.service';
 import { BalanceRepository } from './balance.repository';
+import { BalanceCacheService } from './balance-cache.service';
 import { RequestContextService } from '../common/request-context/request-context.service';
 import { BalanceIndexerMetricsService } from './balance-indexer-metrics.service';
 import { randomUUID } from 'crypto';
@@ -78,6 +79,7 @@ export class BalanceIndexerService implements OnModuleInit {
     private readonly webhookEventEmitter: WebhookEventEmitterService,
     private readonly requestContext: RequestContextService,
     private readonly metrics: BalanceIndexerMetricsService,
+    private readonly balanceCache?: BalanceCacheService,
   ) {
     this.staleThresholdMs = this.configService.get<number>(
       'BALANCE_STALE_THRESHOLD_MS',
@@ -271,6 +273,14 @@ export class BalanceIndexerService implements OnModuleInit {
     asset: Asset,
   ): Promise<WalletBalance | null> {
     const requestId = this.requestContext.getRequestId() || 'N/A';
+
+    // Cache-aside: serve from in-memory cache when fresh
+    const cached = this.balanceCache?.get(walletId, asset);
+    if (cached) {
+      this.logger.debug(`[${requestId}] Cache hit for wallet ${walletId} asset ${asset.type}`);
+      return cached;
+    }
+
     const balance = await this.prisma.walletBalance.findUnique({
       where: {
         walletId_assetType_assetCode_assetIssuer: this.assetCompoundKey(
@@ -287,11 +297,11 @@ export class BalanceIndexerService implements OnModuleInit {
         `[${requestId}] Balance is stale for wallet ${walletId}, asset ${asset.type}`,
       );
       // Trigger async refresh — do not await so the caller isn't blocked
-      this.syncWalletBalances({ walletId }).catch((err) =>
-        this.logger.error('Background balance refresh failed:', err),
       this.syncWalletBalancesWithRetry({ walletId }).catch((err) =>
         this.logger.error(`[${requestId}] Background balance refresh failed:`, err),
       );
+    } else {
+      this.balanceCache?.set(walletId, asset, balance as WalletBalance);
     }
 
     return balance;
@@ -477,6 +487,9 @@ export class BalanceIndexerService implements OnModuleInit {
         mismatchesFound,
       });
 
+      // Invalidate cache for this wallet after a successful sync
+      this.balanceCache?.invalidateAll(walletId);
+
       return {
         walletId,
         balancesUpdated,
@@ -489,7 +502,6 @@ export class BalanceIndexerService implements OnModuleInit {
       };
     } catch (error) {
       this.logger.error(`Balance sync failed for wallet ${walletId}:`, error);
-      await this.balanceRepo.markFailed(walletId);
       this.logger.error(`${logPrefix}Balance sync failed for wallet ${walletId}:`, error);
 
       await this.prisma.walletBalance.updateMany({


### PR DESCRIPTION
closes #395 
closes #396 
closes #397 
closes #398


Issue 1 — Balance indexer: Add cache layer stub
Created BalanceCacheService wrapping the existing CacheService with balance-domain key generation (balance:{walletId}:{assetType}:{code}:{issuer}), a 60-second TTL, and get/set/invalidate/invalidateAll helpers. Injected it (optionally) into BalanceIndexerService: getBalance checks the cache first; on a fresh DB hit the result is cached; after a successful sync invalidateAll is called so stale values are never served. Module wired with CacheService + BalanceCacheService providers. 6 unit tests cover the cache contract.

Issue 2 — Balance indexer: Add feature flag guard
Added @UseGuards(FeatureFlagGuard) and @FeatureFlag('BALANCE_INDEXER') at the class level of BalanceIndexerController. Registered FeatureFlagService and FeatureFlagGuard in BalanceIndexerModule. A dedicated spec (balance-indexer.feature-flag.spec.ts) verifies the metadata is present on the controller class and that the guard correctly allows/blocks requests based on the FEATURE_BALANCE_INDEXER env var.

Issue 3 — Key management: Add integration tests
api-key.integration.spec.ts covers the full lifecycle with an in-memory Prisma mock: create (prefix format, hash storage, ACTIVE status, expiry, nonexistent project), validate (format rejection, unknown key, active key, revoked key, expired key), list (all keys, pagination, no hash/plaintext leakage), rotate (new key + both valid during grace, gracePeriodEndsAt set, custom name), and revoke (REVOKED status, idempotency, reason storage, ownership check).

Issue 4 — Key management: Add OpenAPI examples
ApiKeyController now carries @ApiTags('api-keys') on the class and full @ApiOperation, @ApiBody (with named examples), @ApiParam, @ApiQuery, and @ApiResponse (201/400/404 for create; 200/401 for list; 200/401/404 for revoke and rotate) decorators on every endpoint. Unused imports (Delete, ApiProperty) were cleaned up.