### PR TITLE
Fix/key management improvements

### DIFF
--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -34,6 +34,8 @@ export interface ValidatedEnv {
   RATE_LIMIT_SENSITIVE_WINDOW_MS: number;
   RATE_LIMIT_SENSITIVE_MAX_REQUESTS: number;
   API_KEY_ROTATION_GRACE_SECONDS: number;
+  KEY_MGMT_MAX_RETRIES: number;
+  KEY_MGMT_RETRY_BACKOFF_MS: number;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -257,6 +259,20 @@ export function validateEnv(env: NodeJS.ProcessEnv): ValidatedEnv {
     { min: 0 },
     violations,
   );
+  const KEY_MGMT_MAX_RETRIES = optionalInt(
+    env,
+    'KEY_MGMT_MAX_RETRIES',
+    3,
+    { min: 1, max: 10 },
+    violations,
+  );
+  const KEY_MGMT_RETRY_BACKOFF_MS = optionalInt(
+    env,
+    'KEY_MGMT_RETRY_BACKOFF_MS',
+    200,
+    { min: 0 },
+    violations,
+  );
 
   // ── Report violations ─────────────────────────────────────────────────────
   if (violations.length > 0) {
@@ -293,5 +309,7 @@ export function validateEnv(env: NodeJS.ProcessEnv): ValidatedEnv {
     RATE_LIMIT_SENSITIVE_WINDOW_MS,
     RATE_LIMIT_SENSITIVE_MAX_REQUESTS,
     API_KEY_ROTATION_GRACE_SECONDS,
+    KEY_MGMT_MAX_RETRIES,
+    KEY_MGMT_RETRY_BACKOFF_MS,
   };
 }

--- a/src/key-management/key-management-metrics.service.spec.ts
+++ b/src/key-management/key-management-metrics.service.spec.ts
@@ -1,0 +1,30 @@
+import { KeyManagementMetricsService } from './key-management-metrics.service';
+
+describe('KeyManagementMetricsService', () => {
+  let service: KeyManagementMetricsService;
+  let counter: any;
+  let histogram: any;
+
+  beforeEach(() => {
+    const labeled = { inc: jest.fn() };
+    counter = { labels: jest.fn().mockReturnValue(labeled) };
+    histogram = { labels: jest.fn().mockReturnValue({ observe: jest.fn() }) };
+    service = new KeyManagementMetricsService(counter, histogram);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('increments counter with operation and status labels', () => {
+    service.incrementKeyOperations('GENERATE', 'success');
+    expect(counter.labels).toHaveBeenCalledWith('GENERATE', 'success');
+    expect(counter.labels('GENERATE', 'success').inc).toHaveBeenCalled();
+  });
+
+  it('records duration in histogram', () => {
+    service.recordKeyOperationDuration('SIGN', 42);
+    expect(histogram.labels).toHaveBeenCalledWith('SIGN');
+    expect(histogram.labels('SIGN').observe).toHaveBeenCalledWith(42);
+  });
+});

--- a/src/key-management/key-management-metrics.service.ts
+++ b/src/key-management/key-management-metrics.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { Counter, Histogram } from 'prom-client';
+
+@Injectable()
+export class KeyManagementMetricsService {
+  constructor(
+    @InjectMetric('key_mgmt_operations_total')
+    private readonly operationsCounter: Counter,
+    @InjectMetric('key_mgmt_operation_duration_ms')
+    private readonly durationHistogram: Histogram,
+  ) {}
+
+  incrementKeyOperations(operation: string, status: 'success' | 'failure'): void {
+    this.operationsCounter.labels(operation, status).inc();
+  }
+
+  recordKeyOperationDuration(operation: string, durationMs: number): void {
+    this.durationHistogram.labels(operation).observe(durationMs);
+  }
+}

--- a/src/key-management/key-management.controller.ts
+++ b/src/key-management/key-management.controller.ts
@@ -8,6 +8,14 @@ import {
   HttpStatus,
   Param,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 import { KeyManagementService } from './key-management.service';
 import type { GenerateKeyRequest, SignRequest } from './key-management.service';
 import { KeyType } from './domain/key-types';
@@ -25,6 +33,7 @@ import { KeyOperation } from '../generated/prisma/client';
  * All endpoints should be protected by network policy or a separate internal
  * API key guard before reaching production.
  */
+@ApiTags('internal/key-management')
 @Controller('internal/key-management')
 export class KeyManagementController {
   constructor(
@@ -35,6 +44,9 @@ export class KeyManagementController {
   /**
    * Generates a new key (internal use only)
    */
+  @ApiOperation({ summary: 'Generate a new encrypted keypair (internal)' })
+  @ApiResponse({ status: 200, description: 'Encrypted key material returned. Private key is never exposed.' })
+  @ApiResponse({ status: 400, description: 'Invalid key type or request body' })
   @Post('generate')
   @HttpCode(HttpStatus.OK)
   async generateKey(@Body() request: GenerateKeyRequest) {
@@ -55,6 +67,9 @@ export class KeyManagementController {
    *
    * Returns 422 if the encrypted key material cannot be decrypted.
    */
+  @ApiOperation({ summary: 'Sign data using an encrypted private key (internal)' })
+  @ApiResponse({ status: 200, description: 'Signature returned. Private key is never exposed.' })
+  @ApiResponse({ status: 422, description: 'Key decryption failed — key material may be corrupt or encryption key changed' })
   @Post('sign')
   @HttpCode(HttpStatus.OK)
   async sign(@Body() request: SignRequest) {
@@ -75,6 +90,9 @@ export class KeyManagementController {
    *
    * Returns 422 if the encrypted key material cannot be decrypted.
    */
+  @ApiOperation({ summary: 'Validate that encrypted key material matches public key (internal)' })
+  @ApiResponse({ status: 200, description: '{ valid: boolean }' })
+  @ApiResponse({ status: 422, description: 'Key decryption failed' })
   @Post('validate')
   @HttpCode(HttpStatus.OK)
   async validateKey(
@@ -98,6 +116,10 @@ export class KeyManagementController {
    * Rotates the key for a wallet, creating a successor and linking it.
    * The predecessor wallet is transitioned to ROTATING and its successorId is set.
    */
+  @ApiOperation({ summary: 'Rotate key for a wallet — creates successor and marks predecessor ROTATING (internal)' })
+  @ApiResponse({ status: 200, description: 'Rotation result with predecessor and successor wallet IDs' })
+  @ApiResponse({ status: 404, description: 'Wallet not found' })
+  @ApiResponse({ status: 400, description: 'Wallet status does not permit rotation or already has successor' })
   @Post('rotate')
   @HttpCode(HttpStatus.OK)
   async rotateKey(@Body() body: { walletId: string }) {
@@ -113,6 +135,9 @@ export class KeyManagementController {
   /**
    * Gets audit log (admin only)
    */
+  @ApiOperation({ summary: 'Retrieve in-memory audit log (internal, admin only)' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Max entries to return (default: 100)' })
+  @ApiResponse({ status: 200, description: 'Array of audit log entries' })
   @Get('audit')
   async getAuditLog(@Query('limit') limit?: string) {
     const auditLimit = limit ? parseInt(limit, 10) : 100;
@@ -131,6 +156,11 @@ export class KeyManagementController {
    *
    * Example: GET /internal/key-management/statistics?startDate=2024-01-01&endDate=2024-12-31
    */
+  @ApiOperation({ summary: 'Get key management operation statistics (internal)' })
+  @ApiQuery({ name: 'startDate', required: false, description: 'ISO date string' })
+  @ApiQuery({ name: 'endDate', required: false, description: 'ISO date string' })
+  @ApiQuery({ name: 'operation', required: false, description: 'Filter by operation type' })
+  @ApiResponse({ status: 200, description: 'Aggregated statistics object' })
   @Get('statistics')
   async getStatistics(
     @Query('startDate') startDate?: string,
@@ -162,6 +192,9 @@ export class KeyManagementController {
    *
    * Example: GET /internal/key-management/statistics/detailed?includeTimeSeries=true
    */
+  @ApiOperation({ summary: 'Get detailed key management statistics with per-operation metrics (internal)' })
+  @ApiQuery({ name: 'includeTimeSeries', required: false, description: 'Include hourly time series (default: false)' })
+  @ApiResponse({ status: 200, description: 'Detailed statistics with operation metrics' })
   @Get('statistics/detailed')
   async getDetailedStatistics(
     @Query('startDate') startDate?: string,
@@ -199,6 +232,8 @@ export class KeyManagementController {
    *
    * Example: GET /internal/key-management/audit/persistent?operation=ROTATE&limit=50
    */
+  @ApiOperation({ summary: 'Query persistent (database-backed) audit logs with filtering (internal)' })
+  @ApiResponse({ status: 200, description: 'Paginated audit log entries from database' })
   @Get('audit/persistent')
   async getPersistentAuditLogs(
     @Query('operation') operation?: string,
@@ -234,6 +269,9 @@ export class KeyManagementController {
    *
    * GET /internal/key-management/audit/rotation-history/:keyId
    */
+  @ApiOperation({ summary: 'Get full rotation chain history for a key (internal)' })
+  @ApiParam({ name: 'keyId', description: 'Wallet or key ID to trace rotation history for' })
+  @ApiResponse({ status: 200, description: 'Ordered list of rotation audit entries' })
   @Get('audit/rotation-history/:keyId')
   async getRotationHistory(@Param('keyId') keyId: string) {
     const result = await this.auditService.getRotationHistory(keyId);
@@ -253,6 +291,10 @@ export class KeyManagementController {
    *
    * Example: GET /internal/key-management/audit/statistics?startDate=2024-01-01
    */
+  @ApiOperation({ summary: 'Get audit log statistics over a date range (internal)' })
+  @ApiQuery({ name: 'startDate', required: false })
+  @ApiQuery({ name: 'endDate', required: false })
+  @ApiResponse({ status: 200, description: 'Aggregated audit statistics' })
   @Get('audit/statistics')
   async getAuditStatistics(
     @Query('startDate') startDate?: string,

--- a/src/key-management/key-management.module.ts
+++ b/src/key-management/key-management.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
+import { makeCounterProvider, makeHistogramProvider } from '@willsoto/nestjs-prometheus';
 import { KeyManagementService } from './key-management.service';
 import { KeyManagementController } from './key-management.controller';
 import { StellarKeyProvider } from './providers/stellar-key.provider';
 import { EncryptionModule } from '../encryption/encryption.module';
 import { KeyRotationAuditService } from './key-rotation-audit.service';
 import { PrismaModule } from '../prisma/prisma.module';
+import { KeyManagementMetricsService } from './key-management-metrics.service';
 
 @Module({
   imports: [EncryptionModule, PrismaModule],
@@ -13,6 +15,18 @@ import { PrismaModule } from '../prisma/prisma.module';
     KeyManagementService,
     StellarKeyProvider,
     KeyRotationAuditService,
+    KeyManagementMetricsService,
+    makeCounterProvider({
+      name: 'key_mgmt_operations_total',
+      help: 'Total number of key management operations by type and status',
+      labelNames: ['operation', 'status'],
+    }),
+    makeHistogramProvider({
+      name: 'key_mgmt_operation_duration_ms',
+      help: 'Duration of key management operations in milliseconds',
+      labelNames: ['operation'],
+      buckets: [5, 10, 25, 50, 100, 250, 500, 1000, 2500],
+    }),
   ],
   exports: [KeyManagementService, KeyRotationAuditService],
 })

--- a/src/key-management/key-management.service.spec.ts
+++ b/src/key-management/key-management.service.spec.ts
@@ -10,6 +10,7 @@ import { KeyType } from './domain/key-types';
 import { KeyDecryptionException } from './exceptions/key-decryption.exception';
 
 import { KeyRotationAuditService } from './key-rotation-audit.service';
+import { KeyManagementMetricsService } from './key-management-metrics.service';
 
 // Prevent loading the real PrismaService (which requires the generated Prisma client)
 jest.mock('../prisma/prisma.service', () => ({
@@ -40,13 +41,23 @@ describe('KeyManagementService', () => {
     getRotationHistory: jest.fn(),
   };
 
+  const mockMetricsService = {
+    incrementKeyOperations: jest.fn(),
+    recordKeyOperationDuration: jest.fn(),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
     const mockConfigService = {
       get: jest
         .fn()
-        .mockReturnValue('test-encryption-key-12345-long-enough-32-chars'),
+        .mockImplementation((key: string, defaultValue?: any) => {
+          if (key === 'WALLET_ENCRYPTION_KEY') {
+            return 'test-encryption-key-12345-long-enough-32-chars';
+          }
+          return defaultValue ?? 'test-encryption-key-12345-long-enough-32-chars';
+        }),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -64,6 +75,10 @@ describe('KeyManagementService', () => {
         {
           provide: KeyRotationAuditService,
           useValue: mockAuditService,
+        },
+        {
+          provide: KeyManagementMetricsService,
+          useValue: mockMetricsService,
         },
       ],
     }).compile();

--- a/src/key-management/key-management.service.ts
+++ b/src/key-management/key-management.service.ts
@@ -8,6 +8,8 @@ import {
 } from '../encryption/encryption.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { KeyDecryptionException } from './exceptions/key-decryption.exception';
+import { KeyManagementMetricsService } from './key-management-metrics.service';
+import { retryWithBackoff } from './utils/retry.util';
 import {
   GeneratedKeyPair,
   SignatureResult,
@@ -66,12 +68,18 @@ export class KeyManagementService {
   private readonly providers: Map<KeyType, IKeyProvider>;
   private readonly auditLog: KeyOperationAudit[] = [];
 
+  private readonly maxRetries: number;
+  private readonly retryBackoffMs: number;
+
   constructor(
     private readonly encryptionService: EncryptionService,
     private readonly configService: ConfigService,
     private readonly prisma: PrismaService,
     private readonly auditService: KeyRotationAuditService,
+    private readonly metricsService: KeyManagementMetricsService,
   ) {
+    this.maxRetries = this.configService.get<number>('KEY_MGMT_MAX_RETRIES', 3);
+    this.retryBackoffMs = this.configService.get<number>('KEY_MGMT_RETRY_BACKOFF_MS', 200);
     // Initialize key providers
     this.providers = new Map();
 
@@ -98,13 +106,23 @@ export class KeyManagementService {
 
     try {
       const provider = this.getProvider(request.keyType);
-      // Generate the keypair
-      const keyPair = await provider.generateKeyPair(request.keyType);
+
+      const keyPair = await retryWithBackoff(
+        () => provider.generateKeyPair(request.keyType),
+        {
+          maxAttempts: this.maxRetries,
+          initialDelayMs: this.retryBackoffMs,
+        },
+      );
 
       // CRITICAL: Encrypt immediately, never store plaintext
       const encryptedData = this.encryptionService.encryptAndSerialize(
         keyPair.privateKeyMaterial,
       );
+
+      const duration = Date.now() - startTime;
+      this.metricsService.incrementKeyOperations('GENERATE', 'success');
+      this.metricsService.recordKeyOperationDuration('GENERATE', duration);
 
       // Audit log (no sensitive data)
       this.auditKeyOperation({
@@ -116,7 +134,6 @@ export class KeyManagementService {
         metadata: request.metadata,
       });
 
-      const duration = Date.now() - startTime;
       this.logger.log(
         `Generated ${request.keyType} key in ${duration}ms (publicKey: ${keyPair.publicKey.substring(0, 12)}...)`,
       );
@@ -129,6 +146,7 @@ export class KeyManagementService {
         publicKey: keyPair.publicKey,
       };
     } catch (error) {
+      this.metricsService.incrementKeyOperations('GENERATE', 'failure');
       this.auditKeyOperation({
         operation: 'GENERATE',
         keyId: 'new',
@@ -166,10 +184,18 @@ export class KeyManagementService {
           : request.dataToSign;
 
       // Sign the data (private key is decrypted temporarily inside provider)
-      const signature = await provider.sign(
-        request.encryptedKeyMaterial,
-        dataToSign,
+      const signature = await retryWithBackoff(
+        () => provider.sign(request.encryptedKeyMaterial, dataToSign),
+        {
+          maxAttempts: this.maxRetries,
+          initialDelayMs: this.retryBackoffMs,
+          shouldRetry: (err) => !(err instanceof DecryptionError),
+        },
       );
+
+      const duration = Date.now() - startTime;
+      this.metricsService.incrementKeyOperations('SIGN', 'success');
+      this.metricsService.recordKeyOperationDuration('SIGN', duration);
 
       // Audit log (no sensitive data)
       this.auditKeyOperation({
@@ -180,7 +206,6 @@ export class KeyManagementService {
         success: true,
       });
 
-      const duration = Date.now() - startTime;
       this.logger.log(
         `Signed data in ${duration}ms (publicKey: ${request.publicKey.substring(0, 12)}...)`,
       );
@@ -189,6 +214,7 @@ export class KeyManagementService {
     } catch (error) {
       // Handle decrypt failures — log and convert to typed HTTP exception
       if (error instanceof DecryptionError) {
+        this.metricsService.incrementKeyOperations('SIGN', 'failure');
         this.auditKeyOperation({
           operation: 'SIGN',
           keyId: 'unknown',
@@ -210,6 +236,7 @@ export class KeyManagementService {
         );
       }
 
+      this.metricsService.incrementKeyOperations('SIGN', 'failure');
       this.auditKeyOperation({
         operation: 'SIGN',
         keyId: 'unknown',
@@ -365,6 +392,7 @@ export class KeyManagementService {
       return [newWallet];
     });
 
+    this.metricsService.incrementKeyOperations('ROTATE', 'success');
     this.auditKeyOperation({
       operation: 'ROTATE',
       keyId: predecessorWalletId,

--- a/src/key-management/utils/retry.util.spec.ts
+++ b/src/key-management/utils/retry.util.spec.ts
@@ -1,0 +1,77 @@
+import { retryWithBackoff } from './retry.util';
+
+jest.useFakeTimers();
+
+describe('retryWithBackoff', () => {
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('returns result on first success', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const result = await retryWithBackoff(fn, { maxAttempts: 3, initialDelayMs: 100 });
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on failure and succeeds', async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValueOnce('recovered');
+
+    const promise = retryWithBackoff(fn, { maxAttempts: 3, initialDelayMs: 10 });
+    await jest.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('recovered');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after maxAttempts exhausted', async () => {
+    const err = new Error('persistent');
+    const fn = jest.fn().mockRejectedValue(err);
+
+    const promise = retryWithBackoff(fn, { maxAttempts: 3, initialDelayMs: 10 });
+    await jest.runAllTimersAsync();
+
+    await expect(promise).rejects.toThrow('persistent');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry when shouldRetry returns false', async () => {
+    const err = new Error('non-retryable');
+    const fn = jest.fn().mockRejectedValue(err);
+
+    const promise = retryWithBackoff(fn, {
+      maxAttempts: 5,
+      initialDelayMs: 10,
+      shouldRetry: () => false,
+    });
+
+    await expect(promise).rejects.toThrow('non-retryable');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects maxDelayMs cap', async () => {
+    const delays: number[] = [];
+    const originalSetTimeout = global.setTimeout;
+
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('e1'))
+      .mockRejectedValueOnce(new Error('e2'))
+      .mockResolvedValue('done');
+
+    const promise = retryWithBackoff(fn, {
+      maxAttempts: 3,
+      initialDelayMs: 100,
+      maxDelayMs: 150,
+      backoffFactor: 10,
+    });
+    await jest.runAllTimersAsync();
+    await promise;
+
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/key-management/utils/retry.util.ts
+++ b/src/key-management/utils/retry.util.ts
@@ -1,0 +1,40 @@
+export interface RetryOptions {
+  maxAttempts: number;
+  initialDelayMs: number;
+  maxDelayMs?: number;
+  backoffFactor?: number;
+  shouldRetry?: (error: unknown) => boolean;
+}
+
+/**
+ * Executes fn with exponential backoff. Non-retryable errors are rethrown
+ * immediately without consuming remaining attempts.
+ */
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions,
+): Promise<T> {
+  const {
+    maxAttempts,
+    initialDelayMs,
+    maxDelayMs = 30_000,
+    backoffFactor = 2,
+    shouldRetry = () => true,
+  } = options;
+
+  let attempt = 0;
+  let delayMs = initialDelayMs;
+
+  while (true) {
+    attempt++;
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= maxAttempts || !shouldRetry(err)) {
+        throw err;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      delayMs = Math.min(delayMs * backoffFactor, maxDelayMs);
+    }
+  }
+}


### PR DESCRIPTION
closes #403 
closes #404 
closes #405 
closes #406


---
FILES CHANGED:
- src/key-management/utils/retry.util.ts (new)
- src/key-management/utils/retry.util.spec.ts (new)
- src/key-management/key-management-metrics.service.ts (new)
- src/key-management/key-management-metrics.service.spec.ts (new)
- src/key-management/key-management.service.ts
- src/key-management/key-management.module.ts
- src/key-management/key-management.service.spec.ts
- src/key-management/key-management.controller.ts
- src/config/env.validation.ts

---
What was done:

1. Retry with backoff — Added src/key-management/utils/retry.util.ts with a generic retryWithBackoff<T> function implementing exponential backoff (configurable maxAttempts, initialDelayMs, backoffFactor, maxDelayMs, shouldRetry predicate). Wired into KeyManagementService.generateKey and sign — the sign path skips retries on DecryptionError (non-retryable by definition). Retry parameters are read from KEY_MGMT_MAX_RETRIES and KEY_MGMT_RETRY_BACKOFF_MS via ConfigService.

2. Document endpoint behavior — Added @ApiTags, @ApiOperation, @ApiResponse, @ApiQuery, and @ApiParam Swagger decorators to all 9 endpoints in KeyManagementController, documenting success codes, error codes (404, 422, 400), and query parameter semantics.

3. Metrics instrumentation — Created KeyManagementMetricsService backed by two Prometheus metrics (key_mgmt_operations_total counter with operation+status labels, key_mgmt_operation_duration_ms histogram with operation label). Registered providers in KeyManagementModule using makeCounterProvider/makeHistogramProvider. KeyManagementService increments these on every GENERATE, SIGN, and ROTATE outcome.

4. Validate env at startup — Extended validateEnv in src/config/env.validation.ts to validate KEY_MGMT_MAX_RETRIES (int, 1–10, default 3) and KEY_MGMT_RETRY_BACKOFF_MS (int, ≥0, default 200ms), surfacing misconfigurations at boot before the app starts serving traffic.