### PR TITLE
Fix/key management improvements

### DIFF
--- a/src/key-management/domain/key-types.ts
+++ b/src/key-management/domain/key-types.ts
@@ -57,4 +57,6 @@ export interface KeyOperationAudit {
   metadata?: Record<string, any>;
   success: boolean;
   errorMessage?: string;
+  /** Propagated from the inbound HTTP request via RequestContextService. */
+  requestId?: string;
 }

--- a/src/key-management/interfaces/key-management.interface.ts
+++ b/src/key-management/interfaces/key-management.interface.ts
@@ -1,0 +1,39 @@
+import { KeyType } from '../domain/key-types';
+import { KeyStatistics, KeyStatisticsQuery, DetailedKeyStatistics } from '../domain/key-statistics';
+import { EncryptedKeyMaterial, SignatureResult, KeyOperationAudit } from '../domain/key-types';
+import { GenerateKeyRequest, SignRequest, RotateKeyResult } from '../key-management.service';
+
+/**
+ * Public contract for the key management service.
+ * Decouples consumers from the concrete implementation to allow
+ * alternative backends (HSM, KMS, mock) to be swapped in cleanly.
+ */
+export interface IKeyManagementService {
+  generateKey(request: GenerateKeyRequest): Promise<EncryptedKeyMaterial>;
+
+  sign(request: SignRequest): Promise<SignatureResult>;
+
+  validateKey(
+    publicKey: string,
+    encryptedKeyMaterial: string,
+    keyType: KeyType,
+  ): Promise<boolean>;
+
+  reEncryptKey(
+    encryptedKeyMaterial: string,
+    keyType: KeyType,
+    keyId?: string,
+  ): Promise<EncryptedKeyMaterial>;
+
+  rotateKey(predecessorWalletId: string): Promise<RotateKeyResult>;
+
+  getAuditLog(limit?: number): KeyOperationAudit[];
+
+  getStatistics(query?: KeyStatisticsQuery): KeyStatistics;
+
+  getDetailedStatistics(query?: KeyStatisticsQuery): DetailedKeyStatistics;
+
+  resetStatistics(): void;
+}
+
+export const KEY_MANAGEMENT_SERVICE = Symbol('IKeyManagementService');

--- a/src/key-management/key-management.integration.spec.ts
+++ b/src/key-management/key-management.integration.spec.ts
@@ -29,6 +29,8 @@ import { KeyType } from './domain/key-types';
 import { KeyRotationAuditService } from './key-rotation-audit.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { KeyDecryptionException } from './exceptions/key-decryption.exception';
+import { RequestContextService } from '../common/request-context/request-context.service';
+import { KeyValidationCacheService } from './key-validation-cache/key-validation-cache.service';
 
 /** Builds a minimal ConfigService stub that satisfies EncryptionService. */
 function makeConfigService(
@@ -71,6 +73,14 @@ describe('KeyManagement (integration harness)', () => {
             convertToPersistentFormat: jest.fn().mockReturnValue({}),
           },
         },
+        {
+          provide: RequestContextService,
+          useValue: {
+            getRequestId: jest.fn().mockReturnValue(undefined),
+            setRequestId: jest.fn(),
+          },
+        },
+        KeyValidationCacheService,
         {
           provide: PrismaService,
           useValue: {

--- a/src/key-management/key-management.module.ts
+++ b/src/key-management/key-management.module.ts
@@ -5,6 +5,8 @@ import { StellarKeyProvider } from './providers/stellar-key.provider';
 import { EncryptionModule } from '../encryption/encryption.module';
 import { KeyRotationAuditService } from './key-rotation-audit.service';
 import { PrismaModule } from '../prisma/prisma.module';
+import { RequestContextService } from '../common/request-context/request-context.service';
+import { KeyValidationCacheService } from './key-validation-cache/key-validation-cache.service';
 
 @Module({
   imports: [EncryptionModule, PrismaModule],
@@ -13,7 +15,9 @@ import { PrismaModule } from '../prisma/prisma.module';
     KeyManagementService,
     StellarKeyProvider,
     KeyRotationAuditService,
+    RequestContextService,
+    KeyValidationCacheService,
   ],
-  exports: [KeyManagementService, KeyRotationAuditService],
+  exports: [KeyManagementService, KeyRotationAuditService, KeyValidationCacheService],
 })
 export class KeyManagementModule {}

--- a/src/key-management/key-management.service.spec.ts
+++ b/src/key-management/key-management.service.spec.ts
@@ -8,8 +8,9 @@ import {
 } from '../encryption/encryption.service';
 import { KeyType } from './domain/key-types';
 import { KeyDecryptionException } from './exceptions/key-decryption.exception';
-
 import { KeyRotationAuditService } from './key-rotation-audit.service';
+import { RequestContextService } from '../common/request-context/request-context.service';
+import { KeyValidationCacheService } from './key-validation-cache/key-validation-cache.service';
 
 // Prevent loading the real PrismaService (which requires the generated Prisma client)
 jest.mock('../prisma/prisma.service', () => ({
@@ -40,6 +41,19 @@ describe('KeyManagementService', () => {
     getRotationHistory: jest.fn(),
   };
 
+  const mockRequestContext = {
+    getRequestId: jest.fn().mockReturnValue(undefined),
+    setRequestId: jest.fn(),
+  };
+
+  const mockValidationCache = {
+    get: jest.fn().mockReturnValue(undefined),
+    set: jest.fn(),
+    invalidate: jest.fn(),
+    size: jest.fn().mockReturnValue(0),
+    clear: jest.fn(),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -64,6 +78,14 @@ describe('KeyManagementService', () => {
         {
           provide: KeyRotationAuditService,
           useValue: mockAuditService,
+        },
+        {
+          provide: RequestContextService,
+          useValue: mockRequestContext,
+        },
+        {
+          provide: KeyValidationCacheService,
+          useValue: mockValidationCache,
         },
       ],
     }).compile();

--- a/src/key-management/key-management.service.ts
+++ b/src/key-management/key-management.service.ts
@@ -22,6 +22,8 @@ import {
   KeyOperationMetrics,
 } from './domain/key-statistics';
 import { KeyRotationAuditService } from './key-rotation-audit.service';
+import { RequestContextService } from '../common/request-context/request-context.service';
+import { KeyValidationCacheService } from './key-validation-cache/key-validation-cache.service';
 
 export interface GenerateKeyRequest {
   keyType: KeyType;
@@ -71,6 +73,8 @@ export class KeyManagementService {
     private readonly configService: ConfigService,
     private readonly prisma: PrismaService,
     private readonly auditService: KeyRotationAuditService,
+    private readonly requestContext: RequestContextService,
+    private readonly validationCache: KeyValidationCacheService,
   ) {
     // Initialize key providers
     this.providers = new Map();
@@ -234,10 +238,17 @@ export class KeyManagementService {
     encryptedKeyMaterial: string,
     keyType: KeyType,
   ): Promise<boolean> {
+    const cached = this.validationCache.get(publicKey, encryptedKeyMaterial);
+    if (cached !== undefined) {
+      return cached;
+    }
+
     const provider = this.getProvider(keyType);
 
     try {
-      return await provider.validateKeyPair(publicKey, encryptedKeyMaterial);
+      const result = await provider.validateKeyPair(publicKey, encryptedKeyMaterial);
+      this.validationCache.set(publicKey, encryptedKeyMaterial, result);
+      return result;
     } catch (error) {
       if (error instanceof DecryptionError) {
         this.logger.error(
@@ -364,6 +375,10 @@ export class KeyManagementService {
 
       return [newWallet];
     });
+
+    // Invalidate any cached validation result for the predecessor's public key
+    // so subsequent validations hit the real decryption path.
+    this.validationCache.invalidate(predecessor.publicKey);
 
     this.auditKeyOperation({
       operation: 'ROTATE',
@@ -598,30 +613,36 @@ export class KeyManagementService {
 
   /**
    * Audits key operations (NEVER log sensitive data)
+   * Automatically propagates the current request ID from RequestContextService.
    */
   private auditKeyOperation(audit: KeyOperationAudit): void {
-    this.auditLog.push(audit);
+    const enriched: KeyOperationAudit = {
+      ...audit,
+      requestId: audit.requestId ?? this.requestContext.getRequestId(),
+    };
+
+    this.auditLog.push(enriched);
 
     // Persist to database for compliance and long-term retention
     this.auditService
       .persistAuditLog(
-        this.auditService.convertToPersistentFormat(audit, {
-          retentionDays: 365, // Keep audit logs for 1 year
+        this.auditService.convertToPersistentFormat(enriched, {
+          retentionDays: 365,
         }),
       )
       .catch((error) => {
-        // Already logged in service, just ensure it doesn't break the main flow
         this.logger.error(
           'Audit persistence failed (non-blocking):',
           error.message,
         );
       });
 
-    // In production, send to external audit system
+    const reqTag = enriched.requestId ? ` req=${enriched.requestId}` : '';
     this.logger.log(
-      `[AUDIT] ${audit.operation} - ${audit.publicKey.substring(0, 12)}... - ` +
-        `${audit.success ? 'SUCCESS' : 'FAILED'}` +
-        (audit.errorMessage ? ` - ${audit.errorMessage}` : ''),
+      `[AUDIT] ${enriched.operation} - ${enriched.publicKey.substring(0, 12)}... - ` +
+        `${enriched.success ? 'SUCCESS' : 'FAILED'}` +
+        (enriched.errorMessage ? ` - ${enriched.errorMessage}` : '') +
+        reqTag,
     );
 
     // Keep only last 1000 audit entries in memory

--- a/src/key-management/key-validation-cache/key-validation-cache.service.spec.ts
+++ b/src/key-management/key-validation-cache/key-validation-cache.service.spec.ts
@@ -1,0 +1,93 @@
+import { KeyValidationCacheService } from './key-validation-cache.service';
+
+describe('KeyValidationCacheService', () => {
+  let cache: KeyValidationCacheService;
+
+  beforeEach(() => {
+    cache = new KeyValidationCacheService();
+  });
+
+  afterEach(() => {
+    cache.clear();
+    jest.useRealTimers();
+  });
+
+  describe('get / set', () => {
+    it('returns undefined for a key that was never cached', () => {
+      expect(cache.get('GPUB', 'enc')).toBeUndefined();
+    });
+
+    it('returns the cached result within the TTL window', () => {
+      cache.set('GPUB', 'enc', true, 5000);
+      expect(cache.get('GPUB', 'enc')).toBe(true);
+    });
+
+    it('does NOT cache negative results', () => {
+      cache.set('GPUB', 'enc', false, 5000);
+      expect(cache.get('GPUB', 'enc')).toBeUndefined();
+    });
+
+    it('returns undefined after the TTL expires', () => {
+      jest.useFakeTimers();
+      cache.set('GPUB', 'enc', true, 100);
+      jest.advanceTimersByTime(101);
+      expect(cache.get('GPUB', 'enc')).toBeUndefined();
+    });
+
+    it('treats different public keys as distinct cache entries', () => {
+      cache.set('GPUB1', 'enc', true);
+      cache.set('GPUB2', 'enc', true);
+      expect(cache.get('GPUB1', 'enc')).toBe(true);
+      expect(cache.get('GPUB2', 'enc')).toBe(true);
+    });
+
+    it('treats different encrypted material as distinct cache entries', () => {
+      cache.set('GPUB', 'enc1', true);
+      expect(cache.get('GPUB', 'enc2')).toBeUndefined();
+    });
+  });
+
+  describe('invalidate', () => {
+    it('removes all cached entries for a given public key', () => {
+      cache.set('GPUB', 'enc-a', true);
+      cache.set('GPUB', 'enc-b', true);
+      cache.invalidate('GPUB');
+      expect(cache.get('GPUB', 'enc-a')).toBeUndefined();
+      expect(cache.get('GPUB', 'enc-b')).toBeUndefined();
+    });
+
+    it('does not remove entries for other public keys', () => {
+      cache.set('GPUB1', 'enc', true);
+      cache.set('GPUB2', 'enc', true);
+      cache.invalidate('GPUB1');
+      expect(cache.get('GPUB2', 'enc')).toBe(true);
+    });
+
+    it('is a no-op when no entries exist for the key', () => {
+      expect(() => cache.invalidate('GNONE')).not.toThrow();
+    });
+  });
+
+  describe('size', () => {
+    it('returns 0 for an empty cache', () => {
+      expect(cache.size()).toBe(0);
+    });
+
+    it('counts only live (non-expired) entries', () => {
+      jest.useFakeTimers();
+      cache.set('GPUB1', 'enc', true, 100);
+      cache.set('GPUB2', 'enc', true, 10_000);
+      jest.advanceTimersByTime(200);
+      expect(cache.size()).toBe(1);
+    });
+  });
+
+  describe('clear', () => {
+    it('removes all cached entries', () => {
+      cache.set('GPUB1', 'enc', true);
+      cache.set('GPUB2', 'enc', true);
+      cache.clear();
+      expect(cache.size()).toBe(0);
+    });
+  });
+});

--- a/src/key-management/key-validation-cache/key-validation-cache.service.ts
+++ b/src/key-management/key-validation-cache/key-validation-cache.service.ts
@@ -1,0 +1,117 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+interface CacheEntry {
+  result: boolean;
+  expiresAt: number;
+}
+
+/**
+ * In-memory cache stub for key-pair validation results.
+ *
+ * Prevents redundant decryption on hot paths where the same key is validated
+ * repeatedly within a short window (e.g. transaction signing bursts). The TTL
+ * is deliberately short so stale entries do not mask a key that has been
+ * rotated or revoked.
+ *
+ * This is a stub implementation — a production deployment would back this with
+ * Redis so that the cache survives pod restarts and is shared across replicas.
+ */
+@Injectable()
+export class KeyValidationCacheService {
+  private readonly logger = new Logger(KeyValidationCacheService.name);
+
+  private readonly cache = new Map<string, CacheEntry>();
+
+  /** Default TTL in milliseconds (30 seconds). */
+  private readonly DEFAULT_TTL_MS = 30_000;
+
+  /** Maximum number of entries kept in memory at any time. */
+  private readonly MAX_ENTRIES = 1_000;
+
+  /**
+   * Returns a cached validation result for the given key pair, or undefined if
+   * no live entry exists.
+   */
+  get(publicKey: string, encryptedKeyMaterial: string): boolean | undefined {
+    const key = this.buildCacheKey(publicKey, encryptedKeyMaterial);
+    const entry = this.cache.get(key);
+
+    if (!entry) return undefined;
+
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(key);
+      return undefined;
+    }
+
+    return entry.result;
+  }
+
+  /**
+   * Stores a validation result in the cache.
+   * Only caches positive results — negative results (mismatched or invalid
+   * keys) are never cached so that corrected keys are visible immediately.
+   */
+  set(
+    publicKey: string,
+    encryptedKeyMaterial: string,
+    result: boolean,
+    ttlMs: number = this.DEFAULT_TTL_MS,
+  ): void {
+    if (!result) return;
+
+    if (this.cache.size >= this.MAX_ENTRIES) {
+      this.evictExpired();
+
+      if (this.cache.size >= this.MAX_ENTRIES) {
+        this.logger.warn(
+          `KeyValidationCache full (${this.MAX_ENTRIES} entries) — skipping cache write`,
+        );
+        return;
+      }
+    }
+
+    const key = this.buildCacheKey(publicKey, encryptedKeyMaterial);
+    this.cache.set(key, { result, expiresAt: Date.now() + ttlMs });
+  }
+
+  /**
+   * Invalidates all cached entries for a public key (e.g. after key rotation).
+   */
+  invalidate(publicKey: string): void {
+    let removed = 0;
+    for (const k of this.cache.keys()) {
+      if (k.startsWith(`${publicKey}:`)) {
+        this.cache.delete(k);
+        removed++;
+      }
+    }
+    if (removed > 0) {
+      this.logger.debug(`Invalidated ${removed} cache entries for key ${publicKey.substring(0, 12)}...`);
+    }
+  }
+
+  /** Returns the number of live (non-expired) entries currently cached. */
+  size(): number {
+    this.evictExpired();
+    return this.cache.size;
+  }
+
+  /** Clears all entries — useful in tests. */
+  clear(): void {
+    this.cache.clear();
+  }
+
+  private buildCacheKey(publicKey: string, encryptedKeyMaterial: string): string {
+    // Use a short hash of the encrypted material to keep key sizes manageable
+    return `${publicKey}:${encryptedKeyMaterial.substring(0, 32)}`;
+  }
+
+  private evictExpired(): void {
+    const now = Date.now();
+    for (const [k, entry] of this.cache.entries()) {
+      if (now > entry.expiresAt) {
+        this.cache.delete(k);
+      }
+    }
+  }
+}

--- a/test/key-management.e2e-spec.ts
+++ b/test/key-management.e2e-spec.ts
@@ -1,0 +1,570 @@
+/**
+ * Key Management E2E Test Suite
+ *
+ * Tests the HTTP layer of the internal key management endpoints without a real
+ * database or HSM. All persistence dependencies (Prisma, KeyRotationAuditService)
+ * are replaced with lightweight in-memory stubs so the suite runs offline in CI.
+ *
+ * Covers:
+ *  - POST /internal/key-management/generate
+ *  - POST /internal/key-management/sign
+ *  - POST /internal/key-management/validate
+ *  - POST /internal/key-management/rotate
+ *  - GET  /internal/key-management/audit
+ *  - GET  /internal/key-management/statistics
+ *  - GET  /internal/key-management/statistics/detailed
+ *  - Request-ID propagation via x-request-id header
+ *  - Invalid / stale / disconnected states (422, 404, 400)
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { KeyManagementModule } from '../src/key-management/key-management.module';
+import { KeyManagementService } from '../src/key-management/key-management.service';
+import { KeyRotationAuditService } from '../src/key-management/key-rotation-audit.service';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { KeyType } from '../src/key-management/domain/key-types';
+import { ConfigService } from '@nestjs/config';
+import requestLogger from '../src/common/middleware/request-logging.middleware';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfigService(): Partial<ConfigService> {
+  return {
+    get: jest.fn((key: string) => {
+      if (key === 'WALLET_ENCRYPTION_KEY')
+        return 'e2e-test-encryption-key-32chars!!';
+      return undefined;
+    }),
+  };
+}
+
+const mockAuditService = {
+  persistAuditLog: jest.fn().mockResolvedValue(undefined),
+  convertToPersistentFormat: jest.fn().mockReturnValue({}),
+  queryAuditLogs: jest.fn().mockResolvedValue({ logs: [], total: 0 }),
+  getRotationHistory: jest.fn().mockResolvedValue({ history: [] }),
+  getAuditStatistics: jest.fn().mockResolvedValue({ total: 0 }),
+};
+
+const predecessorId = 'wallet-e2e-predecessor';
+const successorId = 'wallet-e2e-successor';
+
+const activePredecessorWallet = {
+  id: predecessorId,
+  userId: 'user-e2e',
+  publicKey: 'GPREDECESSORE2E',
+  encryptedSecret: 'enc-secret',
+  encryptionVersion: 1,
+  secretVersion: 1,
+  network: 'TESTNET',
+  status: 'ACTIVE',
+  successorId: null,
+  rotatedFromId: null,
+};
+
+const mockPrismaService = {
+  wallet: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+  $transaction: jest.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('Key Management (e2e)', () => {
+  let app: INestApplication;
+  let keyManagementService: KeyManagementService;
+
+  beforeAll(async () => {
+    // Set up the $transaction mock to run the callback with a tx proxy
+    mockPrismaService.$transaction.mockImplementation(async (cb: any) => {
+      const tx = {
+        wallet: {
+          create: jest.fn().mockResolvedValue({
+            id: successorId,
+            userId: 'user-e2e',
+            publicKey: 'GSUCCESSORE2E',
+            encryptedSecret: 'enc-new',
+            encryptionVersion: 1,
+            secretVersion: 2,
+            network: 'TESTNET',
+            status: 'ACTIVE',
+            rotatedFromId: predecessorId,
+            successorId: null,
+          }),
+          update: jest.fn().mockResolvedValue({}),
+        },
+      };
+      return cb(tx);
+    });
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [KeyManagementModule],
+    })
+      .overrideProvider(ConfigService)
+      .useValue(makeConfigService())
+      .overrideProvider(KeyRotationAuditService)
+      .useValue(mockAuditService)
+      .overrideProvider(PrismaService)
+      .useValue(mockPrismaService)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(requestLogger as any);
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
+    await app.init();
+
+    keyManagementService =
+      moduleRef.get<KeyManagementService>(KeyManagementService);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    // Reset $transaction mock after each test
+    mockPrismaService.$transaction.mockImplementation(async (cb: any) => {
+      const tx = {
+        wallet: {
+          create: jest.fn().mockResolvedValue({
+            id: successorId,
+            userId: 'user-e2e',
+            publicKey: 'GSUCCESSORE2E',
+            encryptedSecret: 'enc-new',
+            encryptionVersion: 1,
+            secretVersion: 2,
+            network: 'TESTNET',
+            status: 'ACTIVE',
+            rotatedFromId: predecessorId,
+            successorId: null,
+          }),
+          update: jest.fn().mockResolvedValue({}),
+        },
+      };
+      return cb(tx);
+    });
+    mockAuditService.persistAuditLog.mockResolvedValue(undefined);
+    mockAuditService.convertToPersistentFormat.mockReturnValue({});
+    keyManagementService.resetStatistics();
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /internal/key-management/generate
+  // -------------------------------------------------------------------------
+
+  describe('POST /internal/key-management/generate', () => {
+    it('200 – returns encrypted material and public key for STELLAR_ED25519', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/internal/key-management/generate')
+        .send({ keyType: KeyType.STELLAR_ED25519 })
+        .expect(200);
+
+      expect(res.body).toHaveProperty('publicKey');
+      expect(res.body).toHaveProperty('encryptedData');
+      expect(res.body).toHaveProperty('keyType', KeyType.STELLAR_ED25519);
+      expect(res.body).toHaveProperty('encryptionVersion');
+      expect(res.body).toHaveProperty('keyVersion');
+
+      // Security: private key must never appear in the response
+      expect(res.body).not.toHaveProperty('privateKey');
+      expect(res.body).not.toHaveProperty('privateKeyMaterial');
+    });
+
+    it('200 – public key matches Stellar G-address format', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/internal/key-management/generate')
+        .send({ keyType: KeyType.STELLAR_ED25519 })
+        .expect(200);
+
+      expect(res.body.publicKey).toMatch(/^G[A-Z2-7]{55}$/);
+    });
+
+    it('200 – successive calls produce unique key pairs', async () => {
+      const [r1, r2] = await Promise.all([
+        request(app.getHttpServer())
+          .post('/internal/key-management/generate')
+          .send({ keyType: KeyType.STELLAR_ED25519 }),
+        request(app.getHttpServer())
+          .post('/internal/key-management/generate')
+          .send({ keyType: KeyType.STELLAR_ED25519 }),
+      ]);
+
+      expect(r1.body.publicKey).not.toBe(r2.body.publicKey);
+      expect(r1.body.encryptedData).not.toBe(r2.body.encryptedData);
+    });
+
+    it('responds with x-request-id header when x-request-id is sent', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/internal/key-management/generate')
+        .set('x-request-id', 'e2e-test-req-001')
+        .send({ keyType: KeyType.STELLAR_ED25519 })
+        .expect(200);
+
+      expect(res.headers['x-request-id']).toBe('e2e-test-req-001');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /internal/key-management/sign
+  // -------------------------------------------------------------------------
+
+  describe('POST /internal/key-management/sign', () => {
+    it('200 – signs data and returns a base64 signature', async () => {
+      const genRes = await request(app.getHttpServer())
+        .post('/internal/key-management/generate')
+        .send({ keyType: KeyType.STELLAR_ED25519 })
+        .expect(200);
+
+      const { encryptedData, publicKey } = genRes.body;
+
+      const signRes = await request(app.getHttpServer())
+        .post('/internal/key-management/sign')
+        .send({
+          encryptedKeyMaterial: encryptedData,
+          dataToSign: Buffer.from('e2e-test-payload').toString('base64'),
+          publicKey,
+        })
+        .expect(200);
+
+      expect(signRes.body).toHaveProperty('signature');
+      expect(signRes.body).toHaveProperty('publicKey', publicKey);
+      expect(signRes.body).toHaveProperty('algorithm', 'ed25519');
+      expect(signRes.body).toHaveProperty('timestamp');
+
+      expect(signRes.body).not.toHaveProperty('privateKey');
+    });
+
+    it('422 – returns Unprocessable Entity for corrupted key material', async () => {
+      const genRes = await request(app.getHttpServer())
+        .post('/internal/key-management/generate')
+        .send({ keyType: KeyType.STELLAR_ED25519 })
+        .expect(200);
+
+      const { publicKey, encryptedData } = genRes.body;
+      const parsed = JSON.parse(encryptedData);
+      parsed.encryptedData = 'deadbeef'.repeat(8);
+      const corrupted = JSON.stringify(parsed);
+
+      const res = await request(app.getHttpServer())
+        .post('/internal/key-management/sign')
+        .send({
+          encryptedKeyMaterial: corrupted,
+          dataToSign: 'payload',
+          publicKey,
+        })
+        .expect(422);
+
+      expect(res.body).toHaveProperty('error', 'Key Decryption Failed');
+      expect(res.body).toHaveProperty('reason');
+      // Security: raw crypto internals must not leak
+      expect(res.body.message).not.toMatch(/EVP_|openssl/i);
+    });
+
+    it('x-request-id is echoed back on sign response', async () => {
+      const genRes = await request(app.getHttpServer())
+        .post('/internal/key-management/generate')
+        .send({ keyType: KeyType.STELLAR_ED25519 });
+
+      const res = await request(app.getHttpServer())
+        .post('/internal/key-management/sign')
+        .set('x-request-id', 'sign-req-xyz')
+        .send({
+          encryptedKeyMaterial: genRes.body.encryptedData,
+          dataToSign: 'hello',
+          publicKey: genRes.body.publicKey,
+        })
+        .expect(200);
+
+      expect(res.headers['x-request-id']).toBe('sign-req-xyz');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /internal/key-management/validate
+  // -------------------------------------------------------------------------
+
+  describe('POST /internal/key-management/validate', () => {
+    it('200 – returns { valid: true } for a matching key pair', async () => {
+      const genRes = await request(app.getHttpServer())
+        .post('/internal/key-management/generate')
+        .send({ keyType: KeyType.STELLAR_ED25519 });
+
+      const res = await request(app.getHttpServer())
+        .post('/internal/key-management/validate')
+        .send({
+          publicKey: genRes.body.publicKey,
+          encryptedKeyMaterial: genRes.body.encryptedData,
+          keyType: KeyType.STELLAR_ED25519,
+        })
+        .expect(200);
+
+      expect(res.body).toHaveProperty('valid', true);
+    });
+
+    it('200 – returns { valid: false } for a mismatched public key', async () => {
+      const [r1, r2] = await Promise.all([
+        request(app.getHttpServer())
+          .post('/internal/key-management/generate')
+          .send({ keyType: KeyType.STELLAR_ED25519 }),
+        request(app.getHttpServer())
+          .post('/internal/key-management/generate')
+          .send({ keyType: KeyType.STELLAR_ED25519 }),
+      ]);
+
+      const res = await request(app.getHttpServer())
+        .post('/internal/key-management/validate')
+        .send({
+          publicKey: r2.body.publicKey,
+          encryptedKeyMaterial: r1.body.encryptedData,
+          keyType: KeyType.STELLAR_ED25519,
+        })
+        .expect(200);
+
+      expect(res.body).toHaveProperty('valid', false);
+    });
+
+    it('422 – returns Unprocessable Entity for tampered GCM auth tag', async () => {
+      const genRes = await request(app.getHttpServer())
+        .post('/internal/key-management/generate')
+        .send({ keyType: KeyType.STELLAR_ED25519 });
+
+      const parsed = JSON.parse(genRes.body.encryptedData);
+      parsed.tag = 'ff'.repeat(16);
+      const tampered = JSON.stringify(parsed);
+
+      await request(app.getHttpServer())
+        .post('/internal/key-management/validate')
+        .send({
+          publicKey: genRes.body.publicKey,
+          encryptedKeyMaterial: tampered,
+          keyType: KeyType.STELLAR_ED25519,
+        })
+        .expect(422);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /internal/key-management/rotate
+  // -------------------------------------------------------------------------
+
+  describe('POST /internal/key-management/rotate', () => {
+    it('200 – creates successor wallet and returns rotation result', async () => {
+      mockPrismaService.wallet.findUnique.mockResolvedValue(
+        activePredecessorWallet,
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/internal/key-management/rotate')
+        .send({ walletId: predecessorId })
+        .expect(200);
+
+      expect(res.body).toHaveProperty('predecessorWalletId', predecessorId);
+      expect(res.body).toHaveProperty('successorWalletId', successorId);
+      expect(res.body).toHaveProperty('successorPublicKey');
+    });
+
+    it('404 – returns Not Found when wallet does not exist', async () => {
+      mockPrismaService.wallet.findUnique.mockResolvedValue(null);
+
+      await request(app.getHttpServer())
+        .post('/internal/key-management/rotate')
+        .send({ walletId: 'non-existent' })
+        .expect(404);
+    });
+
+    it('500 – returns error when wallet is in a non-rotatable status', async () => {
+      mockPrismaService.wallet.findUnique.mockResolvedValue({
+        ...activePredecessorWallet,
+        status: 'DISABLED',
+      });
+
+      await request(app.getHttpServer())
+        .post('/internal/key-management/rotate')
+        .send({ walletId: predecessorId })
+        .expect(500);
+    });
+
+    it('500 – returns error when wallet already has a successor', async () => {
+      mockPrismaService.wallet.findUnique.mockResolvedValue({
+        ...activePredecessorWallet,
+        successorId: 'already-exists',
+      });
+
+      await request(app.getHttpServer())
+        .post('/internal/key-management/rotate')
+        .send({ walletId: predecessorId })
+        .expect(500);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /internal/key-management/audit
+  // -------------------------------------------------------------------------
+
+  describe('GET /internal/key-management/audit', () => {
+    it('200 – returns audit log array', async () => {
+      await request(app.getHttpServer())
+        .post('/internal/key-management/generate')
+        .send({ keyType: KeyType.STELLAR_ED25519 });
+
+      const res = await request(app.getHttpServer())
+        .get('/internal/key-management/audit')
+        .expect(200);
+
+      expect(res.body).toHaveProperty('logs');
+      expect(Array.isArray(res.body.logs)).toBe(true);
+      expect(res.body.logs.length).toBeGreaterThan(0);
+    });
+
+    it('200 – respects optional limit query param', async () => {
+      // Generate several keys so the log has multiple entries
+      for (let i = 0; i < 5; i++) {
+        await request(app.getHttpServer())
+          .post('/internal/key-management/generate')
+          .send({ keyType: KeyType.STELLAR_ED25519 });
+      }
+
+      const res = await request(app.getHttpServer())
+        .get('/internal/key-management/audit?limit=2')
+        .expect(200);
+
+      expect(res.body.logs.length).toBeLessThanOrEqual(2);
+    });
+
+    it('audit entries include requestId when x-request-id header was sent', async () => {
+      await request(app.getHttpServer())
+        .post('/internal/key-management/generate')
+        .set('x-request-id', 'audit-req-001')
+        .send({ keyType: KeyType.STELLAR_ED25519 });
+
+      const res = await request(app.getHttpServer())
+        .get('/internal/key-management/audit')
+        .expect(200);
+
+      const entry = res.body.logs.find(
+        (l: any) => l.requestId === 'audit-req-001',
+      );
+      expect(entry).toBeDefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /internal/key-management/statistics
+  // -------------------------------------------------------------------------
+
+  describe('GET /internal/key-management/statistics', () => {
+    it('200 – returns statistics object with expected shape', async () => {
+      await request(app.getHttpServer())
+        .post('/internal/key-management/generate')
+        .send({ keyType: KeyType.STELLAR_ED25519 });
+
+      const res = await request(app.getHttpServer())
+        .get('/internal/key-management/statistics')
+        .expect(200);
+
+      expect(res.body).toHaveProperty('success', true);
+      expect(res.body).toHaveProperty('data');
+      expect(res.body.data).toHaveProperty('totalKeysGenerated');
+      expect(res.body.data).toHaveProperty('totalSigningOperations');
+      expect(res.body.data).toHaveProperty('successRate');
+      expect(res.body.data.totalKeysGenerated).toBeGreaterThan(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /internal/key-management/statistics/detailed
+  // -------------------------------------------------------------------------
+
+  describe('GET /internal/key-management/statistics/detailed', () => {
+    it('200 – returns detailed statistics with operationMetrics', async () => {
+      await request(app.getHttpServer())
+        .post('/internal/key-management/generate')
+        .send({ keyType: KeyType.STELLAR_ED25519 });
+
+      const res = await request(app.getHttpServer())
+        .get('/internal/key-management/statistics/detailed')
+        .expect(200);
+
+      expect(res.body).toHaveProperty('success', true);
+      expect(res.body.data).toHaveProperty('operationMetrics');
+      expect(Array.isArray(res.body.data.operationMetrics)).toBe(true);
+    });
+
+    it('200 – includes timeSeries when includeTimeSeries=true', async () => {
+      await request(app.getHttpServer())
+        .post('/internal/key-management/generate')
+        .send({ keyType: KeyType.STELLAR_ED25519 });
+
+      const res = await request(app.getHttpServer())
+        .get(
+          '/internal/key-management/statistics/detailed?includeTimeSeries=true',
+        )
+        .expect(200);
+
+      expect(res.body.data).toHaveProperty('timeSeries');
+      expect(Array.isArray(res.body.data.timeSeries)).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Full flow: generate → sign → validate (via HTTP)
+  // -------------------------------------------------------------------------
+
+  describe('Full generate → sign → validate flow', () => {
+    it('completes the full key lifecycle over HTTP', async () => {
+      // Step 1: generate
+      const genRes = await request(app.getHttpServer())
+        .post('/internal/key-management/generate')
+        .set('x-request-id', 'lifecycle-req-001')
+        .send({ keyType: KeyType.STELLAR_ED25519 })
+        .expect(200);
+
+      const { publicKey, encryptedData } = genRes.body;
+
+      // Step 2: sign
+      const signRes = await request(app.getHttpServer())
+        .post('/internal/key-management/sign')
+        .set('x-request-id', 'lifecycle-req-002')
+        .send({
+          encryptedKeyMaterial: encryptedData,
+          dataToSign: 'full-lifecycle-payload',
+          publicKey,
+        })
+        .expect(200);
+
+      expect(signRes.body.signature).toBeDefined();
+
+      // Step 3: validate
+      const validateRes = await request(app.getHttpServer())
+        .post('/internal/key-management/validate')
+        .set('x-request-id', 'lifecycle-req-003')
+        .send({ publicKey, encryptedKeyMaterial: encryptedData, keyType: KeyType.STELLAR_ED25519 })
+        .expect(200);
+
+      expect(validateRes.body.valid).toBe(true);
+
+      // Step 4: audit trail should capture all 3 request IDs
+      const auditRes = await request(app.getHttpServer())
+        .get('/internal/key-management/audit')
+        .expect(200);
+
+      const ids = auditRes.body.logs
+        .map((l: any) => l.requestId)
+        .filter(Boolean);
+
+      expect(ids).toContain('lifecycle-req-001');
+      expect(ids).toContain('lifecycle-req-002');
+    });
+  });
+});


### PR DESCRIPTION
closes #407 
closes #408 
closes #409 
closes #410



Issue 1 — Add e2e test coverage

test/key-management.e2e-spec.ts — a full HTTP-layer e2e suite that boots a real NestJS application (with Prisma/audit stubs) and exercises every endpoint:

- POST /internal/key-management/generate — happy path, uniqueness, Stellar key format, x-request-id echo
- POST /internal/key-management/sign — happy path, 422 on corrupted ciphertext, x-request-id echo
- POST /internal/key-management/validate — valid pair → true, mismatched key → false, tampered GCM tag → 422
- POST /internal/key-management/rotate — success, 404 for missing wallet, 500 for non-rotatable/already-rotated states
- GET /internal/key-management/audit — array shape, limit param, requestId captured in entries
- GET /internal/key-management/statistics + statistics/detailed — shape, timeSeries flag
- Full generate → sign → validate lifecycle test asserting request IDs are recorded in the audit trail

Issue 2 — Refactor service boundaries

src/key-management/interfaces/key-management.interface.ts — a stable IKeyManagementService interface (with KEY_MANAGEMENT_SERVICE injection token) that declares the full public contract of KeyManagementService. Any future HSM/KMS/mock backend only needs to implement this interface; consumers can depend on the token rather than the concrete class.

Issue 3 — Add request id propagation

- KeyOperationAudit in domain/key-types.ts gains an optional requestId?: string field.
- KeyManagementService.auditKeyOperation() now calls this.requestContext.getRequestId() (via the injected RequestContextService) and attaches the current request ID to every audit entry before persisting it.
- The request ID also appears in the structured log line (req=<id>) for easy log correlation.
- RequestContextService is added to KeyManagementModule providers so it is available for DI.

Issue 4 — Add cache layer stub

src/key-management/key-validation-cache/key-validation-cache.service.ts — an in-memory cache for validateKey results:

- get(publicKey, encryptedKeyMaterial) — returns cached true or undefined (never returns cached false).
- set(...) — stores positive results only, with a 30-second default TTL and a hard cap of 1 000 entries.
- invalidate(publicKey) — removes all entries for a given public key; called automatically by rotateKey after a rotation to prevent the old key from serving stale valid: true responses.
- size() — evicts expired entries then returns live count.
- Full unit spec (key-validation-cache.service.spec.ts) covers get/set/TTL expiry/invalidate/size/clear.