### PR TITLE
Platform improvement: Recovery API enhancements (examples, validation, pagination, filtering)

### DIFF
--- a/src/recovery/dto/create-recovery.dto.ts
+++ b/src/recovery/dto/create-recovery.dto.ts
@@ -1,5 +1,28 @@
+import { IsString, IsNotEmpty, IsOptional, IsObject } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
 export class CreateRecoveryDto {
+  @ApiProperty({
+    description: 'Wallet ID to recover',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsString()
+  @IsNotEmpty()
   walletId: string;
+
+  @ApiProperty({
+    description: 'Requester identifier (user ID or email)',
+    example: 'user_abc123',
+  })
+  @IsString()
+  @IsNotEmpty()
   requester: string;
-  metadata?: any;
+
+  @ApiPropertyOptional({
+    description: 'Arbitrary metadata for the recovery request',
+    example: { reason: 'lost_access', contactEmail: 'user@example.com' },
+  })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
 }

--- a/src/recovery/dto/create-recovery.dto.ts
+++ b/src/recovery/dto/create-recovery.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, IsOptional, IsObject } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, IsObject, IsUUID } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateRecoveryDto {
@@ -6,7 +6,7 @@ export class CreateRecoveryDto {
     description: 'Wallet ID to recover',
     example: '550e8400-e29b-41d4-a716-446655440000',
   })
-  @IsString()
+  @IsUUID('4', { message: 'walletId must be a valid UUID' })
   @IsNotEmpty()
   walletId: string;
 

--- a/src/recovery/dto/paginated-recovery.dto.ts
+++ b/src/recovery/dto/paginated-recovery.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { RecoveryRequest } from '../entities/recovery.entity';
+
+export class PaginatedRecoveryDto {
+  @ApiProperty({ type: [RecoveryRequest], description: 'Array of recovery requests' })
+  data: RecoveryRequest[];
+
+  @ApiProperty({ description: 'Total number of matching records', example: 42 })
+  total: number;
+
+  @ApiProperty({ description: 'Maximum records returned in this page', example: 20 })
+  limit: number;
+
+  @ApiProperty({ description: 'Number of records skipped', example: 0 })
+  offset: number;
+
+  @ApiProperty({ description: 'Whether more records are available', example: true })
+  hasMore: boolean;
+}

--- a/src/recovery/dto/update-recovery.dto.ts
+++ b/src/recovery/dto/update-recovery.dto.ts
@@ -1,7 +1,32 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateRecoveryDto } from './create-recovery.dto';
+import { IsOptional, IsString, IsEnum, IsObject } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { RecoveryStatus } from '../domain/recovery.model';
 
-export class UpdateRecoveryDto extends PartialType(CreateRecoveryDto) {
+export class UpdateRecoveryDto {
+  @ApiPropertyOptional({
+    description: 'New recovery status',
+    enum: RecoveryStatus,
+    example: 'IN_REVIEW',
+  })
+  @IsOptional()
+  @IsEnum(RecoveryStatus, {
+    message: 'status must be a valid RecoveryStatus value',
+  })
   status?: RecoveryStatus;
+
+  @ApiPropertyOptional({
+    description: 'Updated requester identifier',
+    example: 'user_def456',
+  })
+  @IsOptional()
+  @IsString()
+  requester?: string;
+
+  @ApiPropertyOptional({
+    description: 'Arbitrary metadata for the recovery request',
+    example: { reviewNote: 'Approved after ID verification' },
+  })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
 }

--- a/src/recovery/entities/recovery.entity.ts
+++ b/src/recovery/entities/recovery.entity.ts
@@ -1,14 +1,25 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { RecoveryStatus } from '../domain/recovery.model';
 
-/**
- * RecoveryRequest entity class.
- */
 export class RecoveryRequest {
+  @ApiProperty({ description: 'Recovery request UUID', example: '660e8400-e29b-41d4-a716-446655440001' })
   id: string;
+
+  @ApiProperty({ description: 'Wallet ID being recovered', example: '550e8400-e29b-41d4-a716-446655440000' })
   walletId: string;
+
+  @ApiProperty({ description: 'Requester identifier', example: 'user_abc123' })
   requester: string;
+
+  @ApiProperty({ description: 'Current recovery status', enum: RecoveryStatus, example: RecoveryStatus.PENDING })
   status: RecoveryStatus;
+
+  @ApiPropertyOptional({ description: 'Arbitrary metadata', example: { reason: 'lost_access' } })
   metadata?: any | null;
+
+  @ApiProperty({ description: 'Creation timestamp', example: '2026-06-29T12:00:00.000Z' })
   createdAt: Date;
+
+  @ApiProperty({ description: 'Last update timestamp', example: '2026-06-29T12:00:00.000Z' })
   updatedAt: Date;
 }

--- a/src/recovery/recovery.controller.spec.ts
+++ b/src/recovery/recovery.controller.spec.ts
@@ -1,23 +1,46 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RecoveryController } from './recovery.controller';
 import { RecoveryService } from './recovery.service';
+import { RecoveryStatus } from './domain/recovery.model';
+import { BadRequestException } from '@nestjs/common';
 
 describe('RecoveryController', () => {
   let controller: RecoveryController;
+  let service: any;
+
+  const mockRecovery = {
+    id: '660e8400-e29b-41d4-a716-446655440001',
+    walletId: '550e8400-e29b-41d4-a716-446655440000',
+    requester: 'user_abc123',
+    status: RecoveryStatus.PENDING,
+    metadata: null,
+    createdAt: new Date('2026-06-29T12:00:00.000Z'),
+    updatedAt: new Date('2026-06-29T12:00:00.000Z'),
+  };
+
+  const mockPaginatedResponse = {
+    data: [mockRecovery],
+    total: 1,
+    limit: 20,
+    offset: 0,
+    hasMore: false,
+  };
 
   beforeEach(async () => {
+    service = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RecoveryController],
       providers: [
         {
           provide: RecoveryService,
-          useValue: {
-            create: jest.fn(),
-            findAll: jest.fn(),
-            findOne: jest.fn(),
-            update: jest.fn(),
-            remove: jest.fn(),
-          },
+          useValue: service,
         },
       ],
     }).compile();
@@ -27,5 +50,119 @@ describe('RecoveryController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should call service.create', async () => {
+      const dto = {
+        walletId: '550e8400-e29b-41d4-a716-446655440000',
+        requester: 'user_abc123',
+      };
+      service.create.mockResolvedValue(mockRecovery);
+
+      const result = await controller.create(dto);
+
+      expect(service.create).toHaveBeenCalledWith(dto);
+      expect(result).toEqual(mockRecovery);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should call service.findAll with filters and pagination', async () => {
+      service.findAll.mockResolvedValue(mockPaginatedResponse);
+
+      const result = await controller.findAll(
+        '550e8400-e29b-41d4-a716-446655440000',
+        'user_abc',
+        RecoveryStatus.PENDING,
+        '10',
+        '0',
+      );
+
+      expect(service.findAll).toHaveBeenCalledWith({
+        walletId: '550e8400-e29b-41d4-a716-446655440000',
+        requester: 'user_abc',
+        status: RecoveryStatus.PENDING,
+        limit: 10,
+        offset: 0,
+      });
+      expect(result).toEqual(mockPaginatedResponse);
+    });
+
+    it('should pass undefined when query params are omitted', async () => {
+      service.findAll.mockResolvedValue(mockPaginatedResponse);
+
+      const result = await controller.findAll();
+
+      expect(service.findAll).toHaveBeenCalledWith({
+        walletId: undefined,
+        requester: undefined,
+        status: undefined,
+        limit: undefined,
+        offset: undefined,
+      });
+      expect(result).toEqual(mockPaginatedResponse);
+    });
+
+    it('should throw on invalid limit', () => {
+      expect(() =>
+        controller.findAll(undefined, undefined, undefined, '101', undefined),
+      ).toThrow(BadRequestException);
+    });
+
+    it('should throw on negative limit', () => {
+      expect(() =>
+        controller.findAll(undefined, undefined, undefined, '-1', undefined),
+      ).toThrow(BadRequestException);
+    });
+
+    it('should throw on non-integer offset', () => {
+      expect(() =>
+        controller.findAll(undefined, undefined, undefined, undefined, 'abc'),
+      ).toThrow(BadRequestException);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should call service.findOne', async () => {
+      service.findOne.mockResolvedValue(mockRecovery);
+
+      const result = await controller.findOne('660e8400-e29b-41d4-a716-446655440001');
+
+      expect(service.findOne).toHaveBeenCalledWith('660e8400-e29b-41d4-a716-446655440001');
+      expect(result).toEqual(mockRecovery);
+    });
+  });
+
+  describe('update', () => {
+    it('should call service.update', async () => {
+      const dto = { status: RecoveryStatus.IN_REVIEW };
+      service.update.mockResolvedValue({
+        ...mockRecovery,
+        status: RecoveryStatus.IN_REVIEW,
+      });
+
+      const result = await controller.update(
+        '660e8400-e29b-41d4-a716-446655440001',
+        dto,
+      );
+
+      expect(service.update).toHaveBeenCalledWith(
+        '660e8400-e29b-41d4-a716-446655440001',
+        dto,
+      );
+      expect(result.status).toEqual(RecoveryStatus.IN_REVIEW);
+    });
+  });
+
+  describe('remove', () => {
+    it('should call service.remove and return message', async () => {
+      service.remove.mockResolvedValue(undefined);
+
+      const result = await controller.remove('660e8400-e29b-41d4-a716-446655440001');
+
+      expect(service.remove).toHaveBeenCalledWith('660e8400-e29b-41d4-a716-446655440001');
+      expect(result).toEqual({ message: 'Recovery request deleted successfully' });
+    });
   });
 });

--- a/src/recovery/recovery.controller.spec.ts
+++ b/src/recovery/recovery.controller.spec.ts
@@ -121,6 +121,40 @@ describe('RecoveryController', () => {
         controller.findAll(undefined, undefined, undefined, undefined, 'abc'),
       ).toThrow(BadRequestException);
     });
+
+    it('should pass createdAt filter when dates provided', async () => {
+      service.findAll.mockResolvedValue(mockPaginatedResponse);
+
+      const result = await controller.findAll(
+        undefined, undefined, undefined, undefined, undefined,
+        '2026-01-01T00:00:00.000Z', '2026-12-31T23:59:59.999Z',
+      );
+
+      expect(service.findAll).toHaveBeenCalledWith({
+        walletId: undefined,
+        requester: undefined,
+        status: undefined,
+        limit: undefined,
+        offset: undefined,
+        createdAt: {
+          gte: new Date('2026-01-01T00:00:00.000Z'),
+          lte: new Date('2026-12-31T23:59:59.999Z'),
+        },
+      });
+      expect(result).toEqual(mockPaginatedResponse);
+    });
+
+    it('should throw on invalid createdAtFrom date', () => {
+      expect(() =>
+        controller.findAll(undefined, undefined, undefined, undefined, undefined, 'not-a-date', undefined),
+      ).toThrow(BadRequestException);
+    });
+
+    it('should throw on invalid createdAtTo date', () => {
+      expect(() =>
+        controller.findAll(undefined, undefined, undefined, undefined, undefined, undefined, 'bad-date'),
+      ).toThrow(BadRequestException);
+    });
   });
 
   describe('findOne', () => {

--- a/src/recovery/recovery.controller.ts
+++ b/src/recovery/recovery.controller.ts
@@ -6,6 +6,9 @@ import {
   Patch,
   Param,
   Delete,
+  Query,
+  BadRequestException,
+  ParseUUIDPipe,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -19,6 +22,24 @@ import { RecoveryService } from './recovery.service';
 import { CreateRecoveryDto } from './dto/create-recovery.dto';
 import { UpdateRecoveryDto } from './dto/update-recovery.dto';
 import { RecoveryStatus } from './domain/recovery.model';
+
+function parsePaginationParam(
+  value: string | undefined,
+  name: string,
+  max = 100,
+): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) {
+    throw new BadRequestException(
+      `${name} must be a non-negative integer`,
+    );
+  }
+  if (name === 'limit' && n > max) {
+    throw new BadRequestException(`limit must not exceed ${max}`);
+  }
+  return n;
+}
 
 @ApiTags('recovery')
 @Controller('recovery')
@@ -150,9 +171,37 @@ export class RecoveryController {
       },
     },
   })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - invalid status enum value',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: 'status must be a valid RecoveryStatus value: PENDING, IN_REVIEW, APPROVED, REJECTED, COMPLETED, CANCELLED',
+        error: 'Bad Request',
+      },
+    },
+  })
   @Get()
-  findAll() {
-    return this.recoveryService.findAll();
+  findAll(
+    @Query('walletId') walletId?: string,
+    @Query('requester') requester?: string,
+    @Query('status') status?: RecoveryStatus,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
+    if (status !== undefined && !Object.values(RecoveryStatus).includes(status as RecoveryStatus)) {
+      throw new BadRequestException(
+        `status must be a valid RecoveryStatus value: ${Object.values(RecoveryStatus).join(', ')}`,
+      );
+    }
+    return this.recoveryService.findAll({
+      walletId,
+      requester,
+      status: status as RecoveryStatus,
+      limit: parsePaginationParam(limit, 'limit'),
+      offset: parsePaginationParam(offset, 'offset'),
+    });
   }
 
   @ApiOperation({
@@ -180,6 +229,17 @@ export class RecoveryController {
     },
   })
   @ApiResponse({
+    status: 400,
+    description: 'Bad request - invalid UUID',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: 'Validation failed (uuid is expected)',
+        error: 'Bad Request',
+      },
+    },
+  })
+  @ApiResponse({
     status: 404,
     description: 'Recovery request not found',
     schema: {
@@ -191,7 +251,7 @@ export class RecoveryController {
     },
   })
   @Get(':id')
-  findOne(@Param('id') id: string) {
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
     return this.recoveryService.findOne(id);
   }
 
@@ -243,11 +303,11 @@ export class RecoveryController {
   })
   @ApiResponse({
     status: 400,
-    description: 'Bad request - invalid status transition',
+    description: 'Bad request - invalid UUID or invalid status transition',
     schema: {
       example: {
         statusCode: 400,
-        message: 'Invalid recovery status transition: COMPLETED -> PENDING',
+        message: 'Validation failed (uuid is expected)',
         error: 'Bad Request',
       },
     },
@@ -265,7 +325,7 @@ export class RecoveryController {
   })
   @Patch(':id')
   update(
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() updateRecoveryDto: UpdateRecoveryDto,
   ) {
     return this.recoveryService.update(id, updateRecoveryDto);
@@ -288,6 +348,17 @@ export class RecoveryController {
     },
   })
   @ApiResponse({
+    status: 400,
+    description: 'Bad request - invalid UUID',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: 'Validation failed (uuid is expected)',
+        error: 'Bad Request',
+      },
+    },
+  })
+  @ApiResponse({
     status: 404,
     description: 'Recovery request not found',
     schema: {
@@ -299,7 +370,8 @@ export class RecoveryController {
     },
   })
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.recoveryService.remove(id);
+  async remove(@Param('id', ParseUUIDPipe) id: string) {
+    await this.recoveryService.remove(id);
+    return { message: 'Recovery request deleted successfully' };
   }
 }

--- a/src/recovery/recovery.controller.ts
+++ b/src/recovery/recovery.controller.ts
@@ -7,29 +7,262 @@ import {
   Param,
   Delete,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiQuery,
+  ApiParam,
+  ApiBody,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { RecoveryService } from './recovery.service';
 import { CreateRecoveryDto } from './dto/create-recovery.dto';
 import { UpdateRecoveryDto } from './dto/update-recovery.dto';
+import { RecoveryStatus } from './domain/recovery.model';
 
+@ApiTags('recovery')
 @Controller('recovery')
 export class RecoveryController {
   constructor(private readonly recoveryService: RecoveryService) {}
 
+  @ApiOperation({
+    summary: 'Create a recovery request',
+    description:
+      'Create a new recovery request for a wallet. An active recovery request already exists for the same wallet will be rejected.',
+  })
+  @ApiBody({
+    type: CreateRecoveryDto,
+    examples: {
+      default: {
+        summary: 'Standard recovery request',
+        value: {
+          walletId: '550e8400-e29b-41d4-a716-446655440000',
+          requester: 'user_abc123',
+          metadata: {
+            reason: 'lost_access',
+            contactEmail: 'user@example.com',
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Recovery request created successfully',
+    schema: {
+      example: {
+        id: '660e8400-e29b-41d4-a716-446655440001',
+        walletId: '550e8400-e29b-41d4-a716-446655440000',
+        requester: 'user_abc123',
+        status: 'PENDING',
+        metadata: {
+          reason: 'lost_access',
+          contactEmail: 'user@example.com',
+        },
+        createdAt: '2026-06-29T12:00:00.000Z',
+        updatedAt: '2026-06-29T12:00:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - invalid input, wallet not found, or active recovery exists',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: ['walletId must be a UUID', 'requester must be a string'],
+        error: 'Bad Request',
+      },
+    },
+  })
   @Post()
   create(@Body() createRecoveryDto: CreateRecoveryDto) {
     return this.recoveryService.create(createRecoveryDto);
   }
 
+  @ApiOperation({
+    summary: 'List recovery requests with optional filters and pagination',
+    description:
+      'Retrieve a paginated list of recovery requests. Supports filtering by wallet ID, requester, and status.',
+  })
+  @ApiQuery({
+    name: 'walletId',
+    required: false,
+    description: 'Filter by wallet ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @ApiQuery({
+    name: 'requester',
+    required: false,
+    description: 'Filter by requester (partial match, case-insensitive)',
+    example: 'user_abc',
+  })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: RecoveryStatus,
+    description: 'Filter by recovery status',
+    example: 'PENDING',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    description: 'Max records to return (1-100, default 20)',
+    example: 20,
+  })
+  @ApiQuery({
+    name: 'offset',
+    required: false,
+    description: 'Number of records to skip (default 0)',
+    example: 0,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of recovery requests',
+    schema: {
+      example: {
+        data: [
+          {
+            id: '660e8400-e29b-41d4-a716-446655440001',
+            walletId: '550e8400-e29b-41d4-a716-446655440000',
+            requester: 'user_abc123',
+            status: 'PENDING',
+            metadata: { reason: 'lost_access' },
+            createdAt: '2026-06-29T12:00:00.000Z',
+            updatedAt: '2026-06-29T12:00:00.000Z',
+          },
+        ],
+        total: 1,
+        limit: 20,
+        offset: 0,
+        hasMore: false,
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - invalid pagination parameters',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: 'limit must not exceed 100',
+        error: 'Bad Request',
+      },
+    },
+  })
   @Get()
   findAll() {
     return this.recoveryService.findAll();
   }
 
+  @ApiOperation({
+    summary: 'Get a recovery request by ID',
+    description: 'Retrieve a single recovery request by its UUID.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Recovery request UUID',
+    example: '660e8400-e29b-41d4-a716-446655440001',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Recovery request found',
+    schema: {
+      example: {
+        id: '660e8400-e29b-41d4-a716-446655440001',
+        walletId: '550e8400-e29b-41d4-a716-446655440000',
+        requester: 'user_abc123',
+        status: 'PENDING',
+        metadata: { reason: 'lost_access' },
+        createdAt: '2026-06-29T12:00:00.000Z',
+        updatedAt: '2026-06-29T12:00:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Recovery request not found',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: 'Recovery request not found',
+        error: 'Not Found',
+      },
+    },
+  })
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.recoveryService.findOne(id);
   }
 
+  @ApiOperation({
+    summary: 'Update a recovery request status',
+    description:
+      'Update a recovery request status. Valid transitions: PENDING→IN_REVIEW, PENDING→CANCELLED, IN_REVIEW→APPROVED, IN_REVIEW→REJECTED, IN_REVIEW→CANCELLED, APPROVED→COMPLETED, APPROVED→CANCELLED.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Recovery request UUID',
+    example: '660e8400-e29b-41d4-a716-446655440001',
+  })
+  @ApiBody({
+    type: UpdateRecoveryDto,
+    examples: {
+      review: {
+        summary: 'Move to IN_REVIEW',
+        value: { status: 'IN_REVIEW' },
+      },
+      approve: {
+        summary: 'Approve recovery',
+        value: { status: 'APPROVED' },
+      },
+      reject: {
+        summary: 'Reject recovery',
+        value: { status: 'REJECTED' },
+      },
+      complete: {
+        summary: 'Complete recovery',
+        value: { status: 'COMPLETED' },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Recovery request updated',
+    schema: {
+      example: {
+        id: '660e8400-e29b-41d4-a716-446655440001',
+        walletId: '550e8400-e29b-41d4-a716-446655440000',
+        requester: 'user_abc123',
+        status: 'IN_REVIEW',
+        metadata: { reason: 'lost_access' },
+        createdAt: '2026-06-29T12:00:00.000Z',
+        updatedAt: '2026-06-29T12:00:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - invalid status transition',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: 'Invalid recovery status transition: COMPLETED -> PENDING',
+        error: 'Bad Request',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Recovery request not found',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: 'Recovery request not found',
+        error: 'Not Found',
+      },
+    },
+  })
   @Patch(':id')
   update(
     @Param('id') id: string,
@@ -38,6 +271,33 @@ export class RecoveryController {
     return this.recoveryService.update(id, updateRecoveryDto);
   }
 
+  @ApiOperation({
+    summary: 'Delete a recovery request',
+    description: 'Permanently delete a recovery request by ID.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Recovery request UUID',
+    example: '660e8400-e29b-41d4-a716-446655440001',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Recovery request deleted successfully',
+    schema: {
+      example: { message: 'Recovery request deleted successfully' },
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Recovery request not found',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: 'Recovery request not found',
+        error: 'Not Found',
+      },
+    },
+  })
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.recoveryService.remove(id);

--- a/src/recovery/recovery.controller.ts
+++ b/src/recovery/recovery.controller.ts
@@ -137,6 +137,18 @@ export class RecoveryController {
     description: 'Number of records to skip (default 0)',
     example: 0,
   })
+  @ApiQuery({
+    name: 'createdAtFrom',
+    required: false,
+    description: 'Filter records created on or after this ISO date',
+    example: '2026-01-01T00:00:00.000Z',
+  })
+  @ApiQuery({
+    name: 'createdAtTo',
+    required: false,
+    description: 'Filter records created on or before this ISO date',
+    example: '2026-12-31T23:59:59.999Z',
+  })
   @ApiResponse({
     status: 200,
     description: 'Paginated list of recovery requests',
@@ -189,18 +201,38 @@ export class RecoveryController {
     @Query('status') status?: RecoveryStatus,
     @Query('limit') limit?: string,
     @Query('offset') offset?: string,
+    @Query('createdAtFrom') createdAtFrom?: string,
+    @Query('createdAtTo') createdAtTo?: string,
   ) {
     if (status !== undefined && !Object.values(RecoveryStatus).includes(status as RecoveryStatus)) {
       throw new BadRequestException(
         `status must be a valid RecoveryStatus value: ${Object.values(RecoveryStatus).join(', ')}`,
       );
     }
+
+    const createdAtFilter: { gte?: Date; lte?: Date } = {};
+    if (createdAtFrom !== undefined) {
+      const d = new Date(createdAtFrom);
+      if (isNaN(d.getTime())) {
+        throw new BadRequestException('createdAtFrom must be a valid ISO date string');
+      }
+      createdAtFilter.gte = d;
+    }
+    if (createdAtTo !== undefined) {
+      const d = new Date(createdAtTo);
+      if (isNaN(d.getTime())) {
+        throw new BadRequestException('createdAtTo must be a valid ISO date string');
+      }
+      createdAtFilter.lte = d;
+    }
+
     return this.recoveryService.findAll({
       walletId,
       requester,
       status: status as RecoveryStatus,
       limit: parsePaginationParam(limit, 'limit'),
       offset: parsePaginationParam(offset, 'offset'),
+      createdAt: Object.keys(createdAtFilter).length > 0 ? createdAtFilter : undefined,
     });
   }
 

--- a/src/recovery/recovery.service.spec.ts
+++ b/src/recovery/recovery.service.spec.ts
@@ -176,6 +176,41 @@ describe('RecoveryService', () => {
 
       expect(result.hasMore).toEqual(true);
     });
+
+    it('should apply createdAt date range filter', async () => {
+      prisma.recoveryRequest.findMany.mockResolvedValue([mockRecovery]);
+      prisma.recoveryRequest.count.mockResolvedValue(1);
+
+      const from = new Date('2026-01-01T00:00:00.000Z');
+      const to = new Date('2026-12-31T23:59:59.999Z');
+
+      await service.findAll({ createdAt: { gte: from, lte: to } });
+
+      expect(prisma.recoveryRequest.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            createdAt: { gte: from, lte: to },
+          }),
+        }),
+      );
+    });
+
+    it('should apply createdAt gte filter only', async () => {
+      prisma.recoveryRequest.findMany.mockResolvedValue([mockRecovery]);
+      prisma.recoveryRequest.count.mockResolvedValue(1);
+
+      const from = new Date('2026-06-01T00:00:00.000Z');
+
+      await service.findAll({ createdAt: { gte: from } });
+
+      expect(prisma.recoveryRequest.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            createdAt: { gte: from },
+          }),
+        }),
+      );
+    });
   });
 
   describe('findOne', () => {

--- a/src/recovery/recovery.service.spec.ts
+++ b/src/recovery/recovery.service.spec.ts
@@ -1,25 +1,50 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RecoveryService } from './recovery.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { RecoveryStatus } from './domain/recovery.model';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 
 describe('RecoveryService', () => {
   let service: RecoveryService;
+  let prisma: any;
+
+  const mockRecovery = {
+    id: '660e8400-e29b-41d4-a716-446655440001',
+    walletId: '550e8400-e29b-41d4-a716-446655440000',
+    requester: 'user_abc123',
+    status: 'PENDING',
+    metadata: null,
+    createdAt: new Date('2026-06-29T12:00:00.000Z'),
+    updatedAt: new Date('2026-06-29T12:00:00.000Z'),
+  };
+
+  const mockWallet = {
+    id: '550e8400-e29b-41d4-a716-446655440000',
+    address: 'GABC1234567890',
+  };
 
   beforeEach(async () => {
+    prisma = {
+      recoveryRequest: {
+        findFirst: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        count: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+      wallet: {
+        findUnique: jest.fn(),
+      },
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RecoveryService,
         {
           provide: PrismaService,
-          useValue: {
-            recoveryRequest: {
-              findFirst: jest.fn(),
-              findMany: jest.fn(),
-              findUnique: jest.fn(),
-              create: jest.fn(),
-              update: jest.fn(),
-            },
-          },
+          useValue: prisma,
         },
       ],
     }).compile();
@@ -29,5 +54,194 @@ describe('RecoveryService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a recovery request', async () => {
+      prisma.recoveryRequest.findFirst.mockResolvedValue(null);
+      prisma.wallet.findUnique.mockResolvedValue(mockWallet);
+      prisma.recoveryRequest.create.mockResolvedValue(mockRecovery);
+
+      const result = await service.create({
+        walletId: '550e8400-e29b-41d4-a716-446655440000',
+        requester: 'user_abc123',
+      });
+
+      expect(result.id).toEqual(mockRecovery.id);
+      expect(result.status).toEqual(RecoveryStatus.PENDING);
+    });
+
+    it('should throw if active recovery exists', async () => {
+      prisma.recoveryRequest.findFirst.mockResolvedValue(mockRecovery);
+
+      await expect(
+        service.create({
+          walletId: '550e8400-e29b-41d4-a716-446655440000',
+          requester: 'user_abc123',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw if wallet not found', async () => {
+      prisma.recoveryRequest.findFirst.mockResolvedValue(null);
+      prisma.wallet.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.create({
+          walletId: '550e8400-e29b-41d4-a716-446655440000',
+          requester: 'user_abc123',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return paginated results', async () => {
+      prisma.recoveryRequest.findMany.mockResolvedValue([mockRecovery]);
+      prisma.recoveryRequest.count.mockResolvedValue(1);
+
+      const result = await service.findAll();
+
+      expect(result.data).toHaveLength(1);
+      expect(result.total).toEqual(1);
+      expect(result.limit).toEqual(20);
+      expect(result.offset).toEqual(0);
+      expect(result.hasMore).toEqual(false);
+    });
+
+    it('should apply walletId filter', async () => {
+      prisma.recoveryRequest.findMany.mockResolvedValue([mockRecovery]);
+      prisma.recoveryRequest.count.mockResolvedValue(1);
+
+      await service.findAll({ walletId: '550e8400-e29b-41d4-a716-446655440000' });
+
+      expect(prisma.recoveryRequest.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            walletId: '550e8400-e29b-41d4-a716-446655440000',
+          }),
+        }),
+      );
+    });
+
+    it('should apply status filter', async () => {
+      prisma.recoveryRequest.findMany.mockResolvedValue([mockRecovery]);
+      prisma.recoveryRequest.count.mockResolvedValue(1);
+
+      await service.findAll({ status: RecoveryStatus.PENDING });
+
+      expect(prisma.recoveryRequest.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: RecoveryStatus.PENDING,
+          }),
+        }),
+      );
+    });
+
+    it('should apply requester filter with case-insensitive contains', async () => {
+      prisma.recoveryRequest.findMany.mockResolvedValue([mockRecovery]);
+      prisma.recoveryRequest.count.mockResolvedValue(1);
+
+      await service.findAll({ requester: 'user_abc' });
+
+      expect(prisma.recoveryRequest.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            requester: { contains: 'user_abc', mode: 'insensitive' },
+          }),
+        }),
+      );
+    });
+
+    it('should apply pagination params', async () => {
+      prisma.recoveryRequest.findMany.mockResolvedValue([mockRecovery]);
+      prisma.recoveryRequest.count.mockResolvedValue(1);
+
+      await service.findAll({ limit: 10, offset: 5 });
+
+      expect(prisma.recoveryRequest.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 10,
+          skip: 5,
+        }),
+      );
+    });
+
+    it('should set hasMore when more results exist', async () => {
+      prisma.recoveryRequest.findMany.mockResolvedValue([mockRecovery]);
+      prisma.recoveryRequest.count.mockResolvedValue(10);
+
+      const result = await service.findAll({ limit: 1, offset: 0 });
+
+      expect(result.hasMore).toEqual(true);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a recovery request', async () => {
+      prisma.recoveryRequest.findUnique.mockResolvedValue(mockRecovery);
+
+      const result = await service.findOne('660e8400-e29b-41d4-a716-446655440001');
+
+      expect(result.id).toEqual(mockRecovery.id);
+    });
+
+    it('should throw if not found', async () => {
+      prisma.recoveryRequest.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.findOne('nonexistent-id'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('should update recovery status', async () => {
+      prisma.recoveryRequest.findUnique.mockResolvedValue(mockRecovery);
+      prisma.recoveryRequest.update.mockResolvedValue({
+        ...mockRecovery,
+        status: 'IN_REVIEW',
+      });
+
+      const result = await service.update(
+        '660e8400-e29b-41d4-a716-446655440001',
+        { status: RecoveryStatus.IN_REVIEW },
+      );
+
+      expect(result.status).toEqual(RecoveryStatus.IN_REVIEW);
+    });
+
+    it('should throw on invalid transition', async () => {
+      prisma.recoveryRequest.findUnique.mockResolvedValue({
+        ...mockRecovery,
+        status: 'COMPLETED',
+      });
+
+      await expect(
+        service.update('660e8400-e29b-41d4-a716-446655440001', {
+          status: RecoveryStatus.PENDING,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete a recovery request', async () => {
+      prisma.recoveryRequest.findUnique.mockResolvedValue(mockRecovery);
+      prisma.recoveryRequest.delete.mockResolvedValue(mockRecovery);
+
+      await expect(
+        service.remove('660e8400-e29b-41d4-a716-446655440001'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should throw if not found', async () => {
+      prisma.recoveryRequest.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.remove('nonexistent-id'),
+      ).rejects.toThrow(NotFoundException);
+    });
   });
 });

--- a/src/recovery/recovery.service.ts
+++ b/src/recovery/recovery.service.ts
@@ -7,6 +7,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { CreateRecoveryDto } from './dto/create-recovery.dto';
 import { UpdateRecoveryDto } from './dto/update-recovery.dto';
 import { RecoveryRequest } from './entities/recovery.entity';
+import { PaginatedRecoveryDto } from './dto/paginated-recovery.dto';
 import {
   RecoveryStatus,
   transitionRecoveryStatus,
@@ -17,7 +18,6 @@ export class RecoveryService {
   constructor(private prisma: PrismaService) {}
 
   async create(createRecoveryDto: CreateRecoveryDto): Promise<RecoveryRequest> {
-    // Check for existing active recovery
     const existingActive = await this.prisma.recoveryRequest.findFirst({
       where: {
         walletId: createRecoveryDto.walletId,
@@ -37,7 +37,6 @@ export class RecoveryService {
       );
     }
 
-    // Verify wallet exists
     const wallet = await this.prisma.wallet.findUnique({
       where: { id: createRecoveryDto.walletId },
     });
@@ -54,28 +53,50 @@ export class RecoveryService {
       },
     });
 
-    return {
-      id: recovery.id,
-      walletId: recovery.walletId,
-      requester: recovery.requester,
-      status: recovery.status as RecoveryStatus,
-      metadata: recovery.metadata,
-      createdAt: recovery.createdAt,
-      updatedAt: recovery.updatedAt,
-    };
+    return this.mapPrismaToEntity(recovery);
   }
 
-  async findAll(): Promise<RecoveryRequest[]> {
-    const recoveries = await this.prisma.recoveryRequest.findMany();
-    return recoveries.map((r) => ({
-      id: r.id,
-      walletId: r.walletId,
-      requester: r.requester,
-      status: r.status as RecoveryStatus,
-      metadata: r.metadata,
-      createdAt: r.createdAt,
-      updatedAt: r.updatedAt,
-    }));
+  async findAll(filters?: {
+    walletId?: string;
+    requester?: string;
+    status?: RecoveryStatus;
+    limit?: number;
+    offset?: number;
+  }): Promise<PaginatedRecoveryDto> {
+    const where: any = {};
+
+    if (filters?.walletId) {
+      where.walletId = filters.walletId;
+    }
+
+    if (filters?.requester) {
+      where.requester = { contains: filters.requester, mode: 'insensitive' };
+    }
+
+    if (filters?.status) {
+      where.status = filters.status;
+    }
+
+    const limit = filters?.limit ?? 20;
+    const offset = filters?.offset ?? 0;
+
+    const [recoveries, total] = await Promise.all([
+      this.prisma.recoveryRequest.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+        skip: offset,
+      }),
+      this.prisma.recoveryRequest.count({ where }),
+    ]);
+
+    return {
+      data: recoveries.map((r) => this.mapPrismaToEntity(r)),
+      total,
+      limit,
+      offset,
+      hasMore: offset + recoveries.length < total,
+    };
   }
 
   async findOne(id: string): Promise<RecoveryRequest> {
@@ -87,15 +108,7 @@ export class RecoveryService {
       throw new NotFoundException('Recovery request not found');
     }
 
-    return {
-      id: recovery.id,
-      walletId: recovery.walletId,
-      requester: recovery.requester,
-      status: recovery.status as RecoveryStatus,
-      metadata: recovery.metadata,
-      createdAt: recovery.createdAt,
-      updatedAt: recovery.updatedAt,
-    };
+    return this.mapPrismaToEntity(recovery);
   }
 
   async update(
@@ -105,36 +118,45 @@ export class RecoveryService {
     const recovery = await this.findOne(id);
 
     if (updateRecoveryDto.status) {
-      // Enforce state transition
-      const updatedRecovery = transitionRecoveryStatus(
-        recovery,
-        updateRecoveryDto.status,
-      );
+      let updatedRecovery: RecoveryRequest;
+      try {
+        updatedRecovery = transitionRecoveryStatus(
+          recovery,
+          updateRecoveryDto.status,
+        );
+      } catch (e) {
+        throw new BadRequestException(
+          e instanceof Error ? e.message : 'Invalid recovery status transition',
+        );
+      }
 
       const result = await this.prisma.recoveryRequest.update({
         where: { id },
         data: { status: updatedRecovery.status },
       });
 
-      return {
-        id: result.id,
-        walletId: result.walletId,
-        requester: result.requester,
-        status: result.status as RecoveryStatus,
-        metadata: result.metadata,
-        createdAt: result.createdAt,
-        updatedAt: result.updatedAt,
-      };
+      return this.mapPrismaToEntity(result);
     }
 
-    // If no status update, return current
     return recovery;
   }
 
   async remove(id: string): Promise<void> {
-    await this.findOne(id); // Check exists
+    await this.findOne(id);
     await this.prisma.recoveryRequest.delete({
       where: { id },
     });
+  }
+
+  private mapPrismaToEntity(prismaRecovery: any): RecoveryRequest {
+    return {
+      id: prismaRecovery.id,
+      walletId: prismaRecovery.walletId,
+      requester: prismaRecovery.requester,
+      status: prismaRecovery.status as RecoveryStatus,
+      metadata: prismaRecovery.metadata,
+      createdAt: prismaRecovery.createdAt,
+      updatedAt: prismaRecovery.updatedAt,
+    };
   }
 }

--- a/src/recovery/recovery.service.ts
+++ b/src/recovery/recovery.service.ts
@@ -62,6 +62,7 @@ export class RecoveryService {
     status?: RecoveryStatus;
     limit?: number;
     offset?: number;
+    createdAt?: { gte?: Date; lte?: Date };
   }): Promise<PaginatedRecoveryDto> {
     const where: any = {};
 
@@ -75,6 +76,10 @@ export class RecoveryService {
 
     if (filters?.status) {
       where.status = filters.status;
+    }
+
+    if (filters?.createdAt) {
+      where.createdAt = filters.createdAt;
     }
 
     const limit = filters?.limit ?? 20;


### PR DESCRIPTION
Closes #428 
Closes #429 
Closes #430 
Closes #431 
## Summary

This PR introduces four platform improvements to the Mux Protocol Recovery API, enhancing developer experience, robustness, and query capabilities.

## Changes

### 1. Add OpenAPI examples
- Added comprehensive Swagger/OpenAPI decorators with real-world examples across all Recovery endpoints (POST, GET, PATCH, DELETE)
- Decorated `RecoveryRequest` entity and `PaginatedRecoveryDto` with `@ApiProperty` for proper schema generation
- Added `@ApiBody`, `@ApiQuery`, `@ApiParam`, and `@ApiResponse` with detailed example payloads
- Enhanced `CreateRecoveryDto` and `UpdateRecoveryDto` with both Swagger documentation and `class-validator` decorators

### 2. Handle invalid input errors
- Added `ParseUUIDPipe` validation for all `:id` route parameters (GET, PATCH, DELETE by ID)
- Added runtime status enum validation for the `status` query parameter in the list endpoint
- Added `@IsUUID('4')` validation on `walletId` in `CreateRecoveryDto`
- Added `parsePaginationParam` helper with proper validation for `limit` and `offset` query params
- Added try/catch in service to convert domain `Error` to `BadRequestException` for invalid status transitions
- All 400 error responses documented in OpenAPI schemas

### 3. Add pagination support
- Service returns paginated responses with `data`, `total`, `limit`, `offset`, and `hasMore`
- `PaginatedRecoveryDto` fully documented with Swagger decorators
- Default pagination (limit=20, offset=0) when no params provided

### 4. Add filtering query params
- Added `createdAtFrom` and `createdAtTo` query parameters for date range filtering
- ISO date string validation with clear error messages for invalid input
- Prisma `gte`/`lte` filter applied to `createdAt` field
- Supports partial filters (only `createdAtFrom` or only `createdAtTo`)

## Verification
- All 31 recovery unit tests pass (controller + service specs)
- Pagination, filtering, validation, and error handling covered by tests
- Pre-existing test failures in other modules (auth, webhooks, transactions, balance-indexer) are unrelated to this change