### PR TITLE
feat(recovery): add recovery status API for wallets

### DIFF
--- a/src/recovery/dto/wallet-recovery-status.dto.ts
+++ b/src/recovery/dto/wallet-recovery-status.dto.ts
@@ -1,0 +1,9 @@
+import { RecoveryStatus } from '../domain/recovery.model';
+
+export class WalletRecoveryStatusDto {
+  walletId: string;
+  hasActiveRecovery: boolean;
+  currentStatus?: RecoveryStatus;
+  recoveryRequestId?: string;
+  lastUpdatedAt?: Date;
+}

--- a/src/recovery/recovery.controller.ts
+++ b/src/recovery/recovery.controller.ts
@@ -406,4 +406,53 @@ export class RecoveryController {
     await this.recoveryService.remove(id);
     return { message: 'Recovery request deleted successfully' };
   }
+
+  @ApiOperation({
+    summary: 'Get recovery status for a wallet',
+    description: 'Retrieve the recovery status for a specific wallet, including information about any active recovery requests.',
+  })
+  @ApiParam({
+    name: 'walletId',
+    description: 'Wallet UUID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Wallet recovery status retrieved',
+    schema: {
+      example: {
+        walletId: '550e8400-e29b-41d4-a716-446655440000',
+        hasActiveRecovery: true,
+        currentStatus: 'IN_REVIEW',
+        recoveryRequestId: '660e8400-e29b-41d4-a716-446655440001',
+        lastUpdatedAt: '2026-06-29T12:00:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - invalid UUID',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: 'Validation failed (uuid is expected)',
+        error: 'Bad Request',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Wallet not found',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: 'Wallet not found',
+        error: 'Not Found',
+      },
+    },
+  })
+  @Get('wallet/:walletId/status')
+  async getWalletRecoveryStatus(@Param('walletId', ParseUUIDPipe) walletId: string) {
+    return this.recoveryService.getWalletRecoveryStatus(walletId);
+  }
 }

--- a/src/recovery/recovery.service.ts
+++ b/src/recovery/recovery.service.ts
@@ -153,6 +153,38 @@ export class RecoveryService {
     });
   }
 
+  async getWalletRecoveryStatus(walletId: string) {
+    const wallet = await this.prisma.wallet.findUnique({
+      where: { id: walletId },
+    });
+
+    if (!wallet) {
+      throw new NotFoundException('Wallet not found');
+    }
+
+    const recovery = await this.prisma.recoveryRequest.findFirst({
+      where: {
+        walletId,
+        status: {
+          notIn: [
+            RecoveryStatus.REJECTED,
+            RecoveryStatus.COMPLETED,
+            RecoveryStatus.CANCELLED,
+          ],
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return {
+      walletId,
+      hasActiveRecovery: !!recovery,
+      currentStatus: recovery?.status as RecoveryStatus,
+      recoveryRequestId: recovery?.id,
+      lastUpdatedAt: recovery?.updatedAt,
+    };
+  }
+
   private mapPrismaToEntity(prismaRecovery: any): RecoveryRequest {
     return {
       id: prismaRecovery.id,


### PR DESCRIPTION
## Summary

- Added GET /recovery/wallet/:walletId/status endpoint to check recovery status for a specific wallet
- Returns active recovery request status, ID, and last update timestamp
- Includes wallet validation to ensure wallet exists
- Comprehensive Swagger/OpenAPI documentation included

## Validation

- No linter/formatter errors
- No type check errors
- Changes are isolated to recovery module only

Closes #506