### PR TITLE
feat(limits): deactivate spending limits without hard delete

### DIFF
--- a/prisma/migrations/20260724_add_soft_delete_to_wallet_limit/migration.sql
+++ b/prisma/migrations/20260724_add_soft_delete_to_wallet_limit/migration.sql
@@ -1,0 +1,5 @@
+-- Add soft-delete support to WalletLimit
+ALTER TABLE "WalletLimit" ADD COLUMN "deletedAt" TIMESTAMP;
+
+-- Create index for soft-delete queries
+CREATE INDEX "WalletLimit_deletedAt_idx" ON "WalletLimit"("deletedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,7 +66,11 @@ model WalletLimit {
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
 
+  /// Soft-delete timestamp (null = active)
+  deletedAt           DateTime?
+
   @@index([walletId])
+  @@index([deletedAt])
 }
 
 /// Mainnet/testnet separation for all wallets.

--- a/src/limits/limits.service.ts
+++ b/src/limits/limits.service.ts
@@ -57,7 +57,7 @@ export class LimitsService {
       () =>
         this.prisma.walletLimit.upsert({
           where: { walletId },
-          update: { dailyLimit: daily, perTransactionLimit: perTx },
+          update: { dailyLimit: daily, perTransactionLimit: perTx, deletedAt: null },
           create: { walletId, dailyLimit: daily, perTransactionLimit: perTx },
         }),
       3,
@@ -113,11 +113,16 @@ export class LimitsService {
   async getLimits(walletId: string) {
     return retryWithBackoff(
       () =>
-        this.prisma.walletLimit.findUnique({ where: { walletId } }),
+        this.prisma.walletLimit.findUnique({
+          where: { walletId },
+        }),
       3,
       100,
       this.logger,
-    );
+    ).then(limit => {
+      // Exclude soft-deleted limits
+      return limit?.deletedAt ? null : limit;
+    });
   }
 
   async checkLimits(walletId: string, amount: number): Promise<void> {
@@ -201,7 +206,10 @@ export class LimitsService {
     if (!existing)
       throw new NotFoundException(`No limits found for wallet ${walletId}`);
     return retryWithBackoff(
-      () => this.prisma.walletLimit.delete({ where: { walletId } }),
+      () => this.prisma.walletLimit.update({
+        where: { walletId },
+        data: { deletedAt: new Date() },
+      }),
       3,
       100,
       this.logger,


### PR DESCRIPTION
## Summary

- Added soft-delete support to WalletLimit model using deletedAt field
- Modified removeLimits to deactivate limits by setting deletedAt timestamp instead of hard deleting
- Updated getLimits to exclude soft-deleted limits from results
- Modified setLimits to clear deletedAt when reactivating previously deactivated limits
- Added database migration to support soft deletes

## Validation

- No linter/formatter errors
- No type check errors
- Changes preserve backward compatibility

Closes #505