### PR TITLE
feat(wallets): persist per-user network preference

### DIFF
--- a/prisma/migrations/20260724000000_add_user_default_network/migration.sql
+++ b/prisma/migrations/20260724000000_add_user_default_network/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: add defaultNetwork preference to User
+ALTER TABLE "User" ADD COLUMN "defaultNetwork" "WalletNetwork";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,6 +94,10 @@ model User {
   /// Authentication provider type
   authProvider String @default("UNKNOWN")
 
+  /// Preferred network (mainnet/testnet) for wallet operations that don't
+  /// explicitly specify one. Null = no preference set.
+  defaultNetwork WalletNetwork?
+
   /// Last login timestamp
   lastLoginAt DateTime?
 

--- a/src/wallets/dto/set-network-preference.dto.ts
+++ b/src/wallets/dto/set-network-preference.dto.ts
@@ -1,0 +1,14 @@
+import { IsEnum } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { WalletNetwork } from '../domain/wallet.model';
+
+export class SetNetworkPreferenceDto {
+  @ApiProperty({
+    enum: WalletNetwork,
+    example: WalletNetwork.TESTNET,
+    description:
+      'Preferred network for wallet operations that do not explicitly specify one',
+  })
+  @IsEnum(WalletNetwork, { message: 'network must be one of MAINNET, TESTNET' })
+  network: WalletNetwork;
+}

--- a/src/wallets/wallets.controller.spec.ts
+++ b/src/wallets/wallets.controller.spec.ts
@@ -21,6 +21,8 @@ describe('WalletsController', () => {
     getWalletStatus: jest.fn(),
     activateWallet: jest.fn(),
     findWalletsByUserId: jest.fn(),
+    getNetworkPreference: jest.fn(),
+    setNetworkPreference: jest.fn(),
   };
 
   const mockWalletCreationOrchestrator = {
@@ -238,6 +240,43 @@ describe('WalletsController', () => {
       );
       expect(mockWalletsService.findWalletsByUserId).toHaveBeenCalledWith(
         'user-123',
+      );
+    });
+  });
+
+  describe('getNetworkPreference', () => {
+    it('should return the network preference for a userId', async () => {
+      const preference = {
+        userId: 'user-123',
+        defaultNetwork: WalletNetwork.TESTNET,
+      };
+      mockWalletsService.getNetworkPreference.mockResolvedValue(preference);
+
+      await expect(
+        controller.getNetworkPreference('user-123'),
+      ).resolves.toEqual(preference);
+      expect(mockWalletsService.getNetworkPreference).toHaveBeenCalledWith(
+        'user-123',
+      );
+    });
+  });
+
+  describe('setNetworkPreference', () => {
+    it('should persist the network preference for a userId', async () => {
+      const preference = {
+        userId: 'user-123',
+        defaultNetwork: WalletNetwork.MAINNET,
+      };
+      mockWalletsService.setNetworkPreference.mockResolvedValue(preference);
+
+      await expect(
+        controller.setNetworkPreference('user-123', {
+          network: WalletNetwork.MAINNET,
+        }),
+      ).resolves.toEqual(preference);
+      expect(mockWalletsService.setNetworkPreference).toHaveBeenCalledWith(
+        'user-123',
+        WalletNetwork.MAINNET,
       );
     });
   });

--- a/src/wallets/wallets.controller.ts
+++ b/src/wallets/wallets.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Put,
   Body,
   Patch,
   Param,
@@ -25,6 +26,7 @@ import {
 import { WalletsService } from './wallets.service';
 import { CreateWalletDto } from './dto/create-wallet.dto';
 import { UpdateWalletDto } from './dto/update-wallet.dto';
+import { SetNetworkPreferenceDto } from './dto/set-network-preference.dto';
 import { WalletNetwork, WalletStatus } from './domain/wallet.model';
 import { RequireApiKey } from '../api-keys/decorators/require-api-key.decorator';
 import { ApiKeyCtx } from '../api-keys/decorators/api-key-context.decorator';
@@ -158,6 +160,31 @@ export class WalletsController {
   @Get('user/:userId')
   async findByUserId(@Param('userId') userId: string) {
     return this.walletsService.findWalletsByUserId(userId);
+  }
+
+  @ApiOperation({
+    summary: "Get a user's default network preference",
+    description:
+      'Retrieve the persisted mainnet/testnet preference for a user. Requires API key authentication.',
+  })
+  @ApiParam({ name: 'userId', description: 'User ID (UUID)' })
+  @Get('users/:userId/network-preference')
+  async getNetworkPreference(@Param('userId') userId: string) {
+    return this.walletsService.getNetworkPreference(userId);
+  }
+
+  @ApiOperation({
+    summary: "Set a user's default network preference",
+    description:
+      'Persist the mainnet/testnet preference for a user, used by wallet operations that do not explicitly specify a network. Requires API key authentication.',
+  })
+  @ApiParam({ name: 'userId', description: 'User ID (UUID)' })
+  @Put('users/:userId/network-preference')
+  async setNetworkPreference(
+    @Param('userId') userId: string,
+    @Body() dto: SetNetworkPreferenceDto,
+  ) {
+    return this.walletsService.setNetworkPreference(userId, dto.network);
   }
 
   @Get(':id')

--- a/src/wallets/wallets.service.spec.ts
+++ b/src/wallets/wallets.service.spec.ts
@@ -24,10 +24,17 @@ const mockPrismaWallet = {
   count: jest.fn(),
 };
 
+// Shared mock Prisma user methods (used by network preference lookups)
+const mockPrismaUser = {
+  findUnique: jest.fn(),
+  update: jest.fn(),
+};
+
 // Mock the PrismaClient module so new PrismaClient() returns our mock
 jest.mock('../generated/prisma/client', () => ({
   PrismaClient: jest.fn(() => ({
     wallet: mockPrismaWallet,
+    user: mockPrismaUser,
   })),
 }));
 
@@ -722,6 +729,78 @@ describe('WalletsService', () => {
       const result = await service.findAll({ limit: 20, offset: 4 });
 
       expect(result.hasMore).toBe(false);
+    });
+  });
+
+  describe('getNetworkPreference', () => {
+    it('returns the persisted preference for an existing user', async () => {
+      mockPrismaUser.findUnique.mockResolvedValue({
+        id: 'user-1',
+        defaultNetwork: 'TESTNET',
+      });
+
+      const result = await service.getNetworkPreference('user-1');
+
+      expect(mockPrismaUser.findUnique).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+      });
+      expect(result).toEqual({
+        userId: 'user-1',
+        defaultNetwork: WalletNetwork.TESTNET,
+      });
+    });
+
+    it('returns null defaultNetwork when the user has no preference set', async () => {
+      mockPrismaUser.findUnique.mockResolvedValue({
+        id: 'user-1',
+        defaultNetwork: null,
+      });
+
+      const result = await service.getNetworkPreference('user-1');
+
+      expect(result).toEqual({ userId: 'user-1', defaultNetwork: null });
+    });
+
+    it('throws NotFoundException when the user does not exist', async () => {
+      mockPrismaUser.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.getNetworkPreference('missing-user'),
+      ).rejects.toThrow('User with ID missing-user not found');
+    });
+  });
+
+  describe('setNetworkPreference', () => {
+    it('persists the network preference for an existing user', async () => {
+      mockPrismaUser.findUnique.mockResolvedValue({ id: 'user-1' });
+      mockPrismaUser.update.mockResolvedValue({
+        id: 'user-1',
+        defaultNetwork: 'MAINNET',
+      });
+
+      const result = await service.setNetworkPreference(
+        'user-1',
+        WalletNetwork.MAINNET,
+      );
+
+      expect(mockPrismaUser.update).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+        data: { defaultNetwork: WalletNetwork.MAINNET },
+      });
+      expect(result).toEqual({
+        userId: 'user-1',
+        defaultNetwork: WalletNetwork.MAINNET,
+      });
+    });
+
+    it('throws NotFoundException when the user does not exist', async () => {
+      mockPrismaUser.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.setNetworkPreference('missing-user', WalletNetwork.MAINNET),
+      ).rejects.toThrow('User with ID missing-user not found');
+
+      expect(mockPrismaUser.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/wallets/wallets.service.ts
+++ b/src/wallets/wallets.service.ts
@@ -291,6 +291,39 @@ export class WalletsService {
     return wallets.map((wallet) => this.mapPrismaWalletToDomain(wallet));
   }
 
+  /** Retrieves the user's persisted default network preference (null if unset). */
+  async getNetworkPreference(userId: string): Promise<{
+    userId: string;
+    defaultNetwork: WalletNetwork | null;
+  }> {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException(`User with ID ${userId} not found`);
+    return {
+      userId: user.id,
+      defaultNetwork: (user.defaultNetwork as WalletNetwork) ?? null,
+    };
+  }
+
+  /** Persists the user's default network preference for future wallet operations. */
+  async setNetworkPreference(
+    userId: string,
+    network: WalletNetwork,
+  ): Promise<{ userId: string; defaultNetwork: WalletNetwork }> {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException(`User with ID ${userId} not found`);
+
+    const updated = await this.prisma.user.update({
+      where: { id: userId },
+      data: { defaultNetwork: network },
+    });
+
+    this.logger.log(`Set network preference for user ${userId} to ${network}`);
+    return {
+      userId: updated.id,
+      defaultNetwork: updated.defaultNetwork as WalletNetwork,
+    };
+  }
+
   async findAll(filters?: WalletListFilters): Promise<WalletListResult> {
     const where: Record<string, unknown> = {};
 


### PR DESCRIPTION
Closes #476


## Summary
- Adds a persisted mainnet/testnet network preference per user, so wallet operations that don't explicitly specify a network can fall back to the caller's stored default.
- Adds nullable `User.defaultNetwork` column (Prisma migration `20260724000000_add_user_default_network`).
- Adds `WalletsService.getNetworkPreference` / `setNetworkPreference`, both throwing 404 for an unknown `userId`.
- Adds `GET /wallets/users/:userId/network-preference` and `PUT /wallets/users/:userId/network-preference`, reusing the controller's existing guard stack (`ApiKeyGuard`, `RateLimitGuard`, `FeatureFlagGuard`) so authorization behavior is consistent with the rest of the wallets API.
- New `SetNetworkPreferenceDto` validates `network` via `IsEnum(WalletNetwork)`.

## Testing / validation performed
- `npx jest src/wallets/wallets.service.spec.ts` — 33/33 passing (added 5 new cases: get with preference set, get with none set, get 404, set success, set 404).
- `npx jest src/wallets src/users` — no regressions; the 6 suites that still fail (`wallets.controller.spec.ts`, `wallet-creation-orchestrator.*`) do so at `staging` HEAD too, from an unrelated pre-existing duplicate-declaration bug in `wallet-creation-orchestrator.service.ts` (`requestIdLabel` redeclared) — untouched here per scope.
- Isolated `tsc --noEmit` on the touched files shows no new type errors (pre-existing unrelated errors elsewhere in the repo are unchanged).
- `npx prettier --check` passes on all touched files.

## Risks / follow-ups
- Full-repo `pnpm run build` / `pnpm test` were already broken on `staging` before this change (unrelated syntax errors in `balance-indexer.service.ts`, `transactions.service.ts`, `wallet-creation-orchestrator.service.ts`) — out of scope for this issue and left untouched.
- No endpoint currently consumes `defaultNetwork` automatically (e.g. wallet creation still requires an explicit `network`); wiring that fallback in is a natural follow-up if desired.