### PR TITLE
feat(payments): add idempotency keys to payment create

### DIFF
--- a/prisma/migrations/20260724010000_add_payment_idempotency_key/migration.sql
+++ b/prisma/migrations/20260724010000_add_payment_idempotency_key/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Payment" ADD COLUMN "idempotencyKey" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Payment_idempotencyKey_key" ON "Payment"("idempotencyKey");
+
+-- CreateIndex
+CREATE INDEX "Payment_idempotencyKey_idx" ON "Payment"("idempotencyKey");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,8 +44,13 @@ model Payment {
   userId Int // Legacy field
   user   LegacyUser @relation("UserPayments", fields: [userId], references: [id])
 
+  /// Client-supplied idempotency key to prevent duplicate submissions
+  idempotencyKey String? @unique
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([idempotencyKey])
 }
 
 model UserLimit {

--- a/src/limits/limits.service.spec.ts
+++ b/src/limits/limits.service.spec.ts
@@ -4,6 +4,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { LimitsService, LimitExceededException } from './limits.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { MetricsService } from '../metrics/metrics.service';
+import { RequestContextService } from '../common/request-context/request-context.service';
 import { LimitUpdatedEvent } from './events/limit-updated.event';
 import { LimitExceededEvent } from './events/limit-exceeded.event';
 
@@ -12,6 +13,7 @@ describe('LimitsService', () => {
   let prisma: any;
   let eventEmitter: any;
   let metrics: any;
+  let requestContext: any;
 
   const walletId = 'wallet-uuid-1';
 
@@ -31,8 +33,7 @@ describe('LimitsService', () => {
       incrementLimitExceeded: jest.fn(),
       incrementLimitChecks: jest.fn(),
     };
-
-    cacheService = { get: jest.fn(), set: jest.fn(), delete: jest.fn() };
+    requestContext = { getRequestId: jest.fn().mockReturnValue('req-1') };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -40,6 +41,7 @@ describe('LimitsService', () => {
         { provide: PrismaService, useValue: prisma },
         { provide: EventEmitter2, useValue: eventEmitter },
         { provide: MetricsService, useValue: metrics },
+        { provide: RequestContextService, useValue: requestContext },
       ],
     }).compile();
 

--- a/src/limits/limits.service.ts
+++ b/src/limits/limits.service.ts
@@ -14,6 +14,7 @@ import { LimitUpdatedEvent } from './events/limit-updated.event';
 import { LimitExceededEvent } from './events/limit-exceeded.event';
 import { retryWithBackoff } from '../common/utils/retry';
 import { MetricsService } from '../metrics/metrics.service';
+import { RequestContextService } from '../common/request-context/request-context.service';
 
 export const LIMIT_ERROR_CODES = {
   PER_TX_LIMIT_EXCEEDED: 'LIMIT_PER_TX_EXCEEDED',
@@ -40,6 +41,7 @@ export class LimitsService {
     private readonly prisma: PrismaService,
     private readonly eventEmitter: EventEmitter2,
     private readonly metrics: MetricsService,
+    private readonly requestContext: RequestContextService,
   ) {}
 
   async setLimits(walletId: string, daily: number, perTx: number) {

--- a/src/metrics/metrics.module.ts
+++ b/src/metrics/metrics.module.ts
@@ -32,6 +32,10 @@ import { MetricsController } from './metrics.controller';
       help: 'Total number of limit checks performed',
       labelNames: ['result'],
     }),
+    makeCounterProvider({
+      name: 'payment_idempotency_hits_total',
+      help: 'Total number of payment create requests deduplicated via idempotency key',
+    }),
   ],
   exports: [MetricsService],
 })

--- a/src/metrics/metrics.service.spec.ts
+++ b/src/metrics/metrics.service.spec.ts
@@ -7,6 +7,7 @@ describe('MetricsService', () => {
   let paymentProcessingHistogram: any;
   let limitExceededCounter: any;
   let limitChecksCounter: any;
+  let paymentIdempotencyHitsCounter: any;
 
   beforeEach(() => {
     const labeledCounter = { inc: jest.fn() };
@@ -15,6 +16,7 @@ describe('MetricsService', () => {
     paymentProcessingHistogram = { observe: jest.fn() };
     limitExceededCounter = { labels: jest.fn().mockReturnValue(labeledCounter) };
     limitChecksCounter = { labels: jest.fn().mockReturnValue(labeledCounter) };
+    paymentIdempotencyHitsCounter = { inc: jest.fn() };
 
     service = new MetricsService(
       paymentsCreatedCounter,
@@ -22,6 +24,7 @@ describe('MetricsService', () => {
       paymentProcessingHistogram,
       limitExceededCounter,
       limitChecksCounter,
+      paymentIdempotencyHitsCounter,
     );
   });
 
@@ -59,6 +62,14 @@ describe('MetricsService', () => {
       service.incrementLimitChecks('allowed');
 
       expect(limitChecksCounter.labels).toHaveBeenCalledWith('allowed');
+    });
+  });
+
+  describe('payment idempotency metrics', () => {
+    it('should increment payment_idempotency_hits_total counter', () => {
+      service.incrementPaymentIdempotencyHit();
+
+      expect(paymentIdempotencyHitsCounter.inc).toHaveBeenCalled();
     });
   });
 });

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -15,6 +15,8 @@ export class MetricsService {
     private readonly limitExceededCounter: Counter,
     @InjectMetric('limit_checks_total')
     private readonly limitChecksCounter: Counter,
+    @InjectMetric('payment_idempotency_hits_total')
+    private readonly paymentIdempotencyHitsCounter: Counter,
   ) {}
 
   incrementPaymentsCreated(): void {
@@ -35,5 +37,9 @@ export class MetricsService {
 
   incrementLimitChecks(result: 'allowed' | 'denied'): void {
     this.limitChecksCounter.labels(result).inc();
+  }
+
+  incrementPaymentIdempotencyHit(): void {
+    this.paymentIdempotencyHitsCounter.inc();
   }
 }

--- a/src/payments/dto/create-payment.dto.ts
+++ b/src/payments/dto/create-payment.dto.ts
@@ -72,4 +72,15 @@ export class CreatePaymentDto {
   @IsNotEmpty({ message: 'toId is required' })
   @Min(1, { message: 'toId must be greater than 0' })
   toId: number;
+
+  /** Client-supplied idempotency key. Replaying the same key returns the original payment instead of creating a duplicate. */
+  @ApiProperty({
+    example: 'a1b2c3d4-e5f6-4789-a012-3456789abcde',
+    description:
+      'Optional client-supplied idempotency key. Reusing the same key returns the original payment instead of creating a duplicate.',
+    required: false,
+  })
+  @IsString({ message: 'idempotencyKey must be a string' })
+  @IsOptional()
+  idempotencyKey?: string;
 }

--- a/src/payments/payments-limits.integration.spec.ts
+++ b/src/payments/payments-limits.integration.spec.ts
@@ -7,6 +7,9 @@ import { PrismaService } from '../prisma/prisma.service';
 import { PaymentStatus } from './entities/payment.entity';
 import { WalletStatus } from '../wallets/domain/wallet.model';
 import { RequestContextService } from '../common/request-context/request-context.service';
+import { PAYMENT_LIMITS_PORT } from './ports/payment-limits.port';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { MetricsService } from '../metrics/metrics.service';
 
 describe('Payments and Limits Integration', () => {
   let paymentsService: PaymentsService;
@@ -46,6 +49,18 @@ describe('Payments and Limits Integration', () => {
         { provide: PAYMENT_LIMITS_PORT, useExisting: LimitsService },
         { provide: WalletsService, useValue: mockWalletsService },
         { provide: RequestContextService, useValue: mockRequestContext },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+        {
+          provide: MetricsService,
+          useValue: {
+            incrementPaymentsCreated: jest.fn(),
+            incrementPaymentsFailed: jest.fn(),
+            recordPaymentProcessingDuration: jest.fn(),
+            incrementPaymentIdempotencyHit: jest.fn(),
+            incrementLimitExceeded: jest.fn(),
+            incrementLimitChecks: jest.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/src/payments/payments.controller.ts
+++ b/src/payments/payments.controller.ts
@@ -41,7 +41,7 @@ export class PaymentsController {
 
   @ApiOperation({
     summary: 'Create a new payment',
-    description: 'Create a new payment between wallets. Requires API key authentication. Rate limited to prevent abuse. Emits payment.created event on success.',
+    description: 'Create a new payment between wallets. Requires API key authentication. Rate limited to prevent abuse. Emits payment.created event on success. Pass an idempotencyKey to safely retry without creating a duplicate payment — replaying the same key returns the original payment.',
   })
   @ApiBody({
     type: CreatePaymentDto,
@@ -55,6 +55,7 @@ export class PaymentsController {
           description: 'Payment for services',
           fromId: 1,
           toId: 2,
+          idempotencyKey: 'a1b2c3d4-e5f6-4789-a012-3456789abcde',
         },
       },
     },

--- a/src/payments/payments.module.ts
+++ b/src/payments/payments.module.ts
@@ -3,7 +3,9 @@ import { ConfigModule } from '@nestjs/config';
 import { PaymentsService } from './payments.service';
 import { PaymentsController } from './payments.controller';
 import { LimitsModule } from '../limits/limits.module';
+import { LimitsService } from '../limits/limits.service';
 import { WalletsModule } from '../wallets/wallets.module';
+import { PAYMENT_LIMITS_PORT } from './ports/payment-limits.port';
 import { RequestContextService } from '../common/request-context/request-context.service';
 import { FeatureFlagService } from '../common/feature-flags/feature-flag.service';
 import { FeatureFlagGuard } from '../common/feature-flags/feature-flag.guard';
@@ -13,6 +15,7 @@ import { FeatureFlagGuard } from '../common/feature-flags/feature-flag.guard';
   controllers: [PaymentsController],
   providers: [
     PaymentsService,
+    { provide: PAYMENT_LIMITS_PORT, useExisting: LimitsService },
     RequestContextService,
     FeatureFlagService,
     FeatureFlagGuard,

--- a/src/payments/payments.service.spec.ts
+++ b/src/payments/payments.service.spec.ts
@@ -5,6 +5,8 @@ import { PaymentsService } from './payments.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { WalletsService } from '../wallets/wallets.service';
 import { MetricsService } from '../metrics/metrics.service';
+import { PAYMENT_LIMITS_PORT } from './ports/payment-limits.port';
+import { RequestContextService } from '../common/request-context/request-context.service';
 import { WalletStatus } from '../wallets/domain/wallet.model';
 import { PaymentStatus } from './entities/payment.entity';
 import { PaymentCreatedEvent } from './events/payment-created.event';
@@ -34,6 +36,7 @@ describe('PaymentsService', () => {
   let walletsService: any;
   let eventEmitter: any;
   let metrics: any;
+  let requestContext: any;
 
   beforeEach(async () => {
     prisma = {
@@ -52,7 +55,9 @@ describe('PaymentsService', () => {
       incrementPaymentsCreated: jest.fn(),
       incrementPaymentsFailed: jest.fn(),
       recordPaymentProcessingDuration: jest.fn(),
+      incrementPaymentIdempotencyHit: jest.fn(),
     };
+    requestContext = { getRequestId: jest.fn().mockReturnValue('req-1') };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -62,6 +67,7 @@ describe('PaymentsService', () => {
         { provide: WalletsService, useValue: walletsService },
         { provide: EventEmitter2, useValue: eventEmitter },
         { provide: MetricsService, useValue: metrics },
+        { provide: RequestContextService, useValue: requestContext },
       ],
     }).compile();
 
@@ -105,6 +111,7 @@ describe('PaymentsService', () => {
           description: BASE_DTO.description,
           userId: BASE_DTO.fromId,
           status: PaymentStatus.PENDING,
+          idempotencyKey: null,
         },
       });
       expect(result.status).toBe(PaymentStatus.PENDING);
@@ -219,7 +226,7 @@ describe('PaymentsService', () => {
       walletsService.findWalletById
         .mockResolvedValueOnce(ACTIVE_WALLET)
         .mockResolvedValueOnce(RECEIVER_WALLET);
-      limitsService.checkLimits.mockResolvedValue(undefined);
+      paymentLimitsPort.checkLimits.mockResolvedValue(undefined);
       prisma.payment.create.mockResolvedValue({
         id: 1,
         ...BASE_DTO,
@@ -288,7 +295,7 @@ describe('PaymentsService', () => {
       walletsService.findWalletById
         .mockResolvedValueOnce(ACTIVE_WALLET)
         .mockResolvedValueOnce(RECEIVER_WALLET);
-      limitsService.checkLimits.mockResolvedValue(undefined);
+      paymentLimitsPort.checkLimits.mockResolvedValue(undefined);
       const payment = {
         id: 1,
         ...BASE_DTO,
@@ -388,6 +395,76 @@ describe('PaymentsService', () => {
       await service.update('1', { description: 'Updated' });
 
       expect(eventEmitter.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('idempotency', () => {
+    const idempotencyKey = 'idem-key-1';
+
+    it('returns the existing payment without creating a duplicate when the key was already used', async () => {
+      const existingPayment = {
+        id: 1,
+        ...BASE_DTO,
+        idempotencyKey,
+        status: PaymentStatus.PENDING,
+      };
+      prisma.payment.findUnique.mockResolvedValue(existingPayment);
+
+      const result = await service.create({ ...BASE_DTO, idempotencyKey });
+
+      expect(prisma.payment.findUnique).toHaveBeenCalledWith({
+        where: { idempotencyKey },
+      });
+      expect(walletsService.findWalletById).not.toHaveBeenCalled();
+      expect(prisma.payment.create).not.toHaveBeenCalled();
+      expect(metrics.incrementPaymentIdempotencyHit).toHaveBeenCalled();
+      expect(result).toBe(existingPayment);
+    });
+
+    it('creates a new payment and stores the key when it has not been used before', async () => {
+      prisma.payment.findUnique.mockResolvedValue(null);
+      walletsService.findWalletById
+        .mockResolvedValueOnce(ACTIVE_WALLET)
+        .mockResolvedValueOnce(RECEIVER_WALLET);
+      paymentLimitsPort.checkLimits.mockResolvedValue(undefined);
+      prisma.payment.create.mockResolvedValue({
+        id: 1,
+        ...BASE_DTO,
+        idempotencyKey,
+        status: PaymentStatus.PENDING,
+      });
+
+      await service.create({ ...BASE_DTO, idempotencyKey });
+
+      expect(prisma.payment.create).toHaveBeenCalledWith({
+        data: {
+          fromId: BASE_DTO.fromId,
+          toId: BASE_DTO.toId,
+          amount: BASE_DTO.amount,
+          currency: BASE_DTO.currency,
+          description: BASE_DTO.description,
+          userId: BASE_DTO.fromId,
+          status: PaymentStatus.PENDING,
+          idempotencyKey,
+        },
+      });
+      expect(metrics.incrementPaymentIdempotencyHit).not.toHaveBeenCalled();
+    });
+
+    it('does not check for an existing payment when no key is provided', async () => {
+      walletsService.findWalletById
+        .mockResolvedValueOnce(ACTIVE_WALLET)
+        .mockResolvedValueOnce(RECEIVER_WALLET);
+      paymentLimitsPort.checkLimits.mockResolvedValue(undefined);
+      prisma.payment.create.mockResolvedValue({
+        id: 1,
+        ...BASE_DTO,
+        status: PaymentStatus.PENDING,
+      });
+
+      await service.create(BASE_DTO);
+
+      expect(prisma.payment.findUnique).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/payments/payments.service.ts
+++ b/src/payments/payments.service.ts
@@ -23,6 +23,7 @@ import { PaymentCompletedEvent } from './events/payment-completed.event';
 import { PaymentFailedEvent } from './events/payment-failed.event';
 import { retryWithBackoff } from '../common/utils/retry';
 import { MetricsService } from '../metrics/metrics.service';
+import { RequestContextService } from '../common/request-context/request-context.service';
 
 // Only PENDING payments can be transitioned; terminal states are immutable.
 const ALLOWED_TRANSITIONS: Record<string, PaymentStatus[]> = {
@@ -42,6 +43,7 @@ export class PaymentsService {
     private readonly walletsService: WalletsService,
     private readonly eventEmitter: EventEmitter2,
     private readonly metrics: MetricsService,
+    private readonly requestContext: RequestContextService,
   ) {}
 
   async create(createPaymentDto: CreatePaymentDto) {
@@ -54,7 +56,21 @@ export class PaymentsService {
       amount,
       currency,
       description,
+      idempotencyKey,
     } = createPaymentDto;
+
+    if (idempotencyKey) {
+      const existing = await this.prisma.payment.findUnique({
+        where: { idempotencyKey },
+      });
+      if (existing) {
+        this.logger.log(
+          `Idempotency hit for key ${idempotencyKey}, returning existing payment ${existing.id} requestId=${requestId}`,
+        );
+        this.metrics.incrementPaymentIdempotencyHit();
+        return existing;
+      }
+    }
 
     const senderWallet = await retryWithBackoff(
       () => this.walletsService.findWalletById(walletId),
@@ -75,7 +91,7 @@ export class PaymentsService {
       this.logger,
     );
     await retryWithBackoff(
-      () => this.limitsService.checkLimits(walletId, amount),
+      () => this.paymentLimitsPort.checkLimits(walletId, amount),
       3,
       100,
       this.logger,
@@ -90,6 +106,7 @@ export class PaymentsService {
         description,
         userId: fromId,
         status: PaymentStatus.PENDING,
+        idempotencyKey: idempotencyKey ?? null,
       },
     });
 

--- a/src/payments/ports/payment-limits.port.ts
+++ b/src/payments/ports/payment-limits.port.ts
@@ -4,5 +4,5 @@ export const PAYMENT_LIMITS_PORT = Symbol('PAYMENT_LIMITS_PORT') as InjectionTok
 
 @Injectable()
 export abstract class PaymentLimitsPort {
-  abstract checkLimits(walletId: string, amount: number): Promise<void> | void;
+  abstract checkLimits(walletId: string, amount: number): Promise<void>;
 }


### PR DESCRIPTION
Closes #477


## Summary
- Adds a client-supplied `idempotencyKey` to `POST /payments`. Replaying the same key returns the original payment instead of creating a duplicate, mirroring the existing `Transaction.idempotencyKey` pattern already used elsewhere in this repo.
- Adds nullable, unique `Payment.idempotencyKey` column + index (migration `20260724010000_add_payment_idempotency_key`).
- `PaymentsService.create()` checks for an existing payment by key up front (before wallet lookups / limit checks) and short-circuits if found; new payments persist the key.
- Adds a `payment_idempotency_hits_total` Prometheus counter.

### Pre-existing bugs fixed (on the direct path of this feature)
`payments.service.ts` and `limits.service.ts` did not actually compile/run before this change:
- `PAYMENT_LIMITS_PORT` was `@Inject`-ed in `PaymentsService` but never bound to a provider in `payments.module.ts` — the module could not instantiate.
- `payments.service.ts` called `this.limitsService.checkLimits(...)`, a field that doesn't exist (it should be `this.paymentLimitsPort`).
- `RequestContextService` was provided by both `payments.module.ts` and `limits.module.ts` but never injected into `PaymentsService`'s/`LimitsService`'s constructors, so `this.requestContext.getRequestId()` threw at runtime.
- `PaymentLimitsPort.checkLimits` was typed `Promise<void> | void`, which doesn't satisfy `retryWithBackoff`'s `() => Promise<T>` constraint once correctly wired.

These are exactly the bugs that were silently breaking daily/per-transaction limit enforcement in production (see #478/#479), and they sit directly in the payment-create path this issue touches, so they're fixed here rather than routed around. No other pre-existing/unrelated bugs elsewhere in the repo were touched.


## Testing / validation performed
- `npx jest src/payments src/limits src/metrics` — 62/63 passing. The 1 remaining failure (`limits.service.spec.ts › should use the cache layer for wallet limits`) is a pre-existing, unrelated test asserting a caching feature that doesn't exist in `LimitsService` — it fails identically on `staging` HEAD and is out of scope for this issue.
- Isolated `tsc --noEmit` on all touched files shows no new type errors (remaining errors are pre-existing, in unrelated files: `key-management`, `webhooks`, `wallet-creation-orchestrator`, `metrics.controller`).
- `npx prettier --check` on touched files: no new formatting issues (the files that warn already warned on `staging` HEAD before this change).
- New tests: idempotent replay returns the existing payment without a duplicate `create` call, a fresh key creates and persists it, and omitting the key skips the lookup entirely.