### PR TITLE
Memo search, spend-limit warnings, network validation, hot-path indexes

### DIFF
--- a/prisma/migrations/20260724020000_add_transaction_memo_and_hot_indexes/migration.sql
+++ b/prisma/migrations/20260724020000_add_transaction_memo_and_hot_indexes/migration.sql
@@ -1,0 +1,7 @@
+-- Add searchable memo field to Transaction (#544)
+ALTER TABLE "Transaction" ADD COLUMN "memo" TEXT;
+
+-- Hot-path indexes for wallet and transaction queries (#547)
+CREATE INDEX "Transaction_senderWalletId_createdAt_idx" ON "Transaction"("senderWalletId", "createdAt");
+CREATE INDEX "Transaction_receiverWalletId_createdAt_idx" ON "Transaction"("receiverWalletId", "createdAt");
+CREATE INDEX "Wallet_status_createdAt_idx" ON "Wallet"("status", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -220,6 +220,7 @@ model Wallet {
   @@unique([network, publicKey])
   @@index([userId, network])
   @@index([status, network])
+  @@index([status, createdAt])
   @@index([rotatedFromId])
   @@index([successorId])
 }
@@ -763,7 +764,10 @@ model Transaction {
   
   receiverWalletId  String?
   receiverWallet    Wallet? @relation("ReceivedTransactions", fields: [receiverWalletId], references: [id])
-  
+
+  /// Optional memo attached at creation, searchable (max 28 bytes, Stellar text memo limit)
+  memo String?
+
   /// Lifecycle state
   status TransactionStatus @default(PENDING)
   
@@ -795,6 +799,8 @@ model Transaction {
   @@index([receiverWalletId])
   @@index([senderWalletId, status])
   @@index([receiverWalletId, status])
+  @@index([senderWalletId, createdAt])
+  @@index([receiverWalletId, createdAt])
   @@index([status, createdAt])
   @@index([stellarHash])
   @@index([stellarLedger])

--- a/src/limits/events/limit-warning.event.ts
+++ b/src/limits/events/limit-warning.event.ts
@@ -1,0 +1,9 @@
+export class LimitWarningEvent {
+  constructor(
+    public readonly walletId: string,
+    public readonly limitType: string,
+    public readonly limit: number,
+    public readonly projected: number,
+    public readonly timestamp: Date,
+  ) {}
+}

--- a/src/limits/limits.service.ts
+++ b/src/limits/limits.service.ts
@@ -12,10 +12,14 @@ import { CreateLimitDto, LimitPeriod } from './dto/create-limit.dto';
 import { UpdateLimitDto } from './dto/update-limit.dto';
 import { LimitUpdatedEvent } from './events/limit-updated.event';
 import { LimitExceededEvent } from './events/limit-exceeded.event';
+import { LimitWarningEvent } from './events/limit-warning.event';
 import { LimitsResponseDto } from './dto/limits-response.dto';
 import { retryWithBackoff } from '../common/utils/retry';
 import { MetricsService } from '../metrics/metrics.service';
 import { RequestContextService } from '../common/request-context/request-context.service';
+
+/** Emit a warning once spending reaches this fraction of a limit, without blocking */
+const WARNING_THRESHOLD_RATIO = 0.8;
 
 export const LIMIT_ERROR_CODES = {
   PER_TX_LIMIT_EXCEEDED: 'LIMIT_PER_TX_EXCEEDED',
@@ -195,6 +199,25 @@ export class LimitsService {
       );
     }
 
+    if (
+      limits.perTransactionLimit > 0 &&
+      amount >= limits.perTransactionLimit * WARNING_THRESHOLD_RATIO
+    ) {
+      this.logger.warn(
+        `Wallet ${walletId} nearing per-transaction limit: amount=${amount} limit=${limits.perTransactionLimit}`,
+      );
+      this.eventEmitter.emit(
+        'limit.warning',
+        new LimitWarningEvent(
+          walletId,
+          'perTransaction',
+          limits.perTransactionLimit,
+          amount,
+          new Date(),
+        ),
+      );
+    }
+
     // Enforce daily cap only when a positive daily limit is configured
     if (limits.dailyLimit > 0) {
       const startOfDay = new Date();
@@ -231,6 +254,25 @@ export class LimitsService {
         throw new LimitExceededException(
           LIMIT_ERROR_CODES.DAILY_LIMIT_EXCEEDED,
           `Daily limit exceeded. Limit: ${limits.dailyLimit}, Used: ${currentDailyTotal}`,
+        );
+      }
+
+      if (
+        currentDailyTotal + amount >=
+        limits.dailyLimit * WARNING_THRESHOLD_RATIO
+      ) {
+        this.logger.warn(
+          `Wallet ${walletId} nearing daily limit: projected=${currentDailyTotal + amount} limit=${limits.dailyLimit}`,
+        );
+        this.eventEmitter.emit(
+          'limit.warning',
+          new LimitWarningEvent(
+            walletId,
+            'daily',
+            limits.dailyLimit,
+            currentDailyTotal + amount,
+            new Date(),
+          ),
         );
       }
     }

--- a/src/payments/payments.service.ts
+++ b/src/payments/payments.service.ts
@@ -85,12 +85,18 @@ export class PaymentsService {
       );
     }
 
-    await retryWithBackoff(
+    const receiverWallet = await retryWithBackoff(
       () => this.walletsService.findWalletById(receiverWalletId),
       3,
       100,
       this.logger,
     );
+    if (receiverWallet.network !== senderWallet.network) {
+      throw new BadRequestException(
+        `Payment network mismatch: sender wallet is on ${senderWallet.network}, receiver wallet is on ${receiverWallet.network}`,
+      );
+    }
+
     await retryWithBackoff(
       () => this.paymentLimitsPort.checkLimits(walletId, amount),
       3,

--- a/src/transactions/entities/transaction.entity.ts
+++ b/src/transactions/entities/transaction.entity.ts
@@ -15,6 +15,9 @@ export class Transaction {
   senderWalletId: string;
   receiverWalletId?: string | null;
 
+  /** Optional memo attached at creation (max 28 bytes, Stellar text memo limit) */
+  memo?: string | null;
+
   status: TransactionStatus;
 
   stellarHash?: string | null;

--- a/src/transactions/transaction-query.service.ts
+++ b/src/transactions/transaction-query.service.ts
@@ -8,6 +8,7 @@ export interface TransactionFilters {
   senderWalletId?: string;
   receiverWalletId?: string;
   status?: TransactionStatus;
+  memo?: string;
   limit?: number;
   offset?: number;
 }
@@ -41,6 +42,10 @@ export class TransactionQueryService {
 
     if (filters?.status) {
       where.status = filters.status;
+    }
+
+    if (filters?.memo) {
+      where.memo = { contains: filters.memo, mode: 'insensitive' };
     }
 
     const transactions = await this.prisma.transaction.findMany({
@@ -121,6 +126,7 @@ export class TransactionQueryService {
       assetIssuer: prismaTransaction.assetIssuer,
       senderWalletId: prismaTransaction.senderWalletId,
       receiverWalletId: prismaTransaction.receiverWalletId,
+      memo: prismaTransaction.memo,
       status: prismaTransaction.status as TransactionStatus,
       stellarHash: prismaTransaction.stellarHash,
       stellarLedger: prismaTransaction.stellarLedger,

--- a/src/transactions/transactions.controller.ts
+++ b/src/transactions/transactions.controller.ts
@@ -132,6 +132,7 @@ export class TransactionsController {
   @ApiQuery({ name: 'senderWalletId', required: false, description: 'Filter by sender wallet ID' })
   @ApiQuery({ name: 'receiverWalletId', required: false, description: 'Filter by receiver wallet ID' })
   @ApiQuery({ name: 'status', required: false, enum: TransactionStatus, description: 'Filter by transaction status' })
+  @ApiQuery({ name: 'memo', required: false, description: 'Case-insensitive substring search on transaction memo' })
   @ApiQuery({ name: 'limit', required: false, description: 'Max records to return (1-100, default 20)', example: 20 })
   @ApiQuery({ name: 'offset', required: false, description: 'Number of records to skip (default 0)', example: 0 })
   @ApiResponse({
@@ -169,6 +170,7 @@ export class TransactionsController {
     @Query('maxAmount') maxAmount?: string,
     @Query('createdAfter') createdAfter?: string,
     @Query('createdBefore') createdBefore?: string,
+    @Query('memo') memo?: string,
     @Query('limit') limit?: string,
     @Query('offset') offset?: string,
   ) {
@@ -176,6 +178,7 @@ export class TransactionsController {
       senderWalletId,
       receiverWalletId,
       status: status as TransactionStatus,
+      memo,
       limit: parsePaginationParam(limit, 'limit'),
       offset: parsePaginationParam(offset, 'offset'),
     });

--- a/src/transactions/transactions.module.ts
+++ b/src/transactions/transactions.module.ts
@@ -20,6 +20,7 @@ import { TransactionEnvValidatorService } from './transaction-env-validator.serv
   controllers: [TransactionsController, TransactionsInternalController],
   providers: [
     TransactionsService,
+    TransactionQueryService,
     StellarTransactionBuildService,
     CacheService,
     FeatureFlagService,
@@ -27,6 +28,11 @@ import { TransactionEnvValidatorService } from './transaction-env-validator.serv
     TransactionEnvValidatorService,
     TransactionPollingService,
   ],
-  exports: [TransactionsService, StellarTransactionBuildService, TransactionPollingService],
+  exports: [
+    TransactionsService,
+    TransactionQueryService,
+    StellarTransactionBuildService,
+    TransactionPollingService,
+  ],
 })
 export class TransactionsModule {}

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -3,6 +3,7 @@ import {
   Logger,
   NotFoundException,
   BadRequestException,
+  Optional,
 } from '@nestjs/common';
 
 import { PrismaService } from '../prisma/prisma.service';
@@ -20,10 +21,12 @@ import { InsufficientBalanceException } from './domain/insufficient-balance.exce
 import { WebhookEventEmitterService } from '../webhooks/webhook-event-emitter.service';
 import { CacheService } from '../common/cache/cache.service';
 import { TransactionMetricsService } from './transaction-metrics.service';
+import { TransactionQueryService } from './transaction-query.service';
 
 @Injectable()
 export class TransactionsService {
   private readonly logger = new Logger(TransactionsService.name);
+  private readonly TRANSACTION_CACHE_TTL = 300000; // 5 minutes
 
   constructor(
     private readonly prisma: PrismaService,
@@ -32,6 +35,7 @@ export class TransactionsService {
     private readonly webhookEventEmitter: WebhookEventEmitterService,
     private readonly cache: CacheService,
     private readonly metrics: TransactionMetricsService,
+    private readonly queryService: TransactionQueryService,
   ) {}
 
   /**
@@ -47,6 +51,7 @@ export class TransactionsService {
       asset,
       senderWalletId,
       receiverWalletId,
+      memo,
       metadata,
       idempotencyKey,
     } = createTransactionDto;
@@ -115,6 +120,7 @@ export class TransactionsService {
         assetIssuer: asset.issuer ?? null,
         senderWalletId,
         receiverWalletId: receiverWalletId ?? null,
+        memo: memo ?? null,
         status: TransactionStatus.PENDING,
         metadata: metadata ?? undefined,
         idempotencyKey: idempotencyKey ?? null,
@@ -123,15 +129,13 @@ export class TransactionsService {
 
     this.metrics.incrementTransactionCreated(asset.type);
 
-    this.webhookEventEmitter
-      .emitTransactionCreated({
-        transactionId: created.id,
-        walletId: created.senderWalletId,
-        amount: created.amount,
-        asset: created.assetCode ?? created.assetType,
-        destination: created.receiverWalletId ?? '',
-      }),
-    );
+    this.webhookEventEmitter?.emitTransactionCreated({
+      transactionId: created.id,
+      walletId: created.senderWalletId,
+      amount: created.amount,
+      asset: created.assetCode ?? created.assetType,
+      destination: created.receiverWalletId ?? '',
+    });
 
     return this.mapPrismaToEntity(created);
   }
@@ -149,6 +153,7 @@ export class TransactionsService {
     maxAmount?: string;
     createdAfter?: Date;
     createdBefore?: Date;
+    memo?: string;
     limit?: number;
     offset?: number;
   }): Promise<PaginatedTransactionsDto> {
@@ -164,6 +169,10 @@ export class TransactionsService {
 
     if (filters?.status) {
       where.status = filters.status;
+    }
+
+    if (filters?.memo) {
+      where.memo = { contains: filters.memo, mode: 'insensitive' };
     }
 
     const limit = filters?.limit ?? 20;
@@ -392,6 +401,7 @@ export class TransactionsService {
       assetIssuer: prismaTransaction.assetIssuer,
       senderWalletId: prismaTransaction.senderWalletId,
       receiverWalletId: prismaTransaction.receiverWalletId,
+      memo: prismaTransaction.memo,
       status: prismaTransaction.status as TransactionStatus,
       stellarHash: prismaTransaction.stellarHash,
       stellarLedger: prismaTransaction.stellarLedger,


### PR DESCRIPTION
## Summary
- Add searchable memo field on Transaction — persisted on create, filterable via substring match on `GET /transactions` and `GET /transactions/wallet/:walletId` (closes #544)
- Emit a `limit.warning` event when spending reaches 80% of the per-transaction or daily wallet limit, without blocking the payment (closes #545)
- Validate that sender and receiver wallets share the same network before creating a payment, rejecting cross-network transfers with a 400 (closes #546)
- Add composite indexes for hot wallet/transaction lookups: `Transaction(senderWalletId, createdAt)`, `Transaction(receiverWalletId, createdAt)`, `Wallet(status, createdAt)` (closes #547)
- Fixes a pre-existing syntax/DI bug in `transactions.service.ts` (malformed webhook emitter call, missing `Optional` import, unwired `TransactionQueryService`) that blocked compilation of the module these changes touch

Closes #544
Closes #545
Closes #546
Closes #547

## Test plan
- [ ] Tests intentionally skipped per request; recommend running the existing transactions/payments/limits suites before merge