### PR TITLE
docs: add Docker Compose local setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# ── Stage 1: install & build ─────────────────────────────────
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Enable corepack for pnpm
+RUN corepack enable && corepack prepare pnpm@9 --activate
+
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm prisma:generate
+RUN pnpm run build
+
+# ── Stage 2: production image ─────────────────────────────────
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@9 --activate
+
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile --prod
+
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/src/generated ./src/generated
+COPY prisma ./prisma
+
+EXPOSE 3000
+
+CMD ["node", "dist/main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.9'
+
+services:
+  # ─────────────────────────────────────────────────────────
+  # PostgreSQL database
+  # ─────────────────────────────────────────────────────────
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: mux
+      POSTGRES_PASSWORD: mux_secret
+      POSTGRES_DB: mux_db
+    ports:
+      - '5432:5432'
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U mux -d mux_db']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # ─────────────────────────────────────────────────────────
+  # Mux backend API
+  # ─────────────────────────────────────────────────────────
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: postgresql://mux:mux_secret@db:5432/mux_db
+      PORT: 3000
+    ports:
+      - '3000:3000'
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  postgres_data:

--- a/docs/DOCKER-COMPOSE-LOCAL.md
+++ b/docs/DOCKER-COMPOSE-LOCAL.md
@@ -1,0 +1,111 @@
+# Docker Compose Local Setup
+
+This guide explains how to run the full mux-backend stack locally using Docker Compose — PostgreSQL + API in one command.
+
+## Prerequisites
+
+| Tool | Minimum version |
+|------|----------------|
+| [Docker](https://docs.docker.com/get-docker/) | 24+ |
+| [Docker Compose](https://docs.docker.com/compose/install/) | v2.20+ |
+
+Node.js and pnpm are **not** required on the host; the build happens inside the container.
+
+---
+
+## Quick start
+
+### 1. Copy and configure environment variables
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` and set at minimum:
+
+| Variable | Description |
+|----------|-------------|
+| `WALLET_ENCRYPTION_KEY` | 32-byte hex secret for Stellar key encryption. Generate with `openssl rand -hex 32`. |
+| `STELLAR_HORIZON_URL` | Horizon endpoint (`https://horizon-testnet.stellar.org` for testnet). |
+| `STELLAR_NETWORK` | `TESTNET` or `PUBLIC`. |
+
+> `DATABASE_URL` is **automatically overridden** by `docker-compose.yml` to point at the bundled Postgres container — you do not need to set it manually.
+
+### 2. Start the stack
+
+```bash
+docker compose up --build
+```
+
+On first run Docker builds the API image and pulls the Postgres image. Subsequent starts reuse the cached layers and are much faster.
+
+### 3. Run database migrations
+
+In a separate terminal (while the stack is running):
+
+```bash
+docker compose exec api npx prisma migrate deploy
+```
+
+### 4. Verify the API is healthy
+
+```bash
+curl http://localhost:3000/v1/health
+```
+
+Expected response:
+
+```json
+{"status":"ok"}
+```
+
+---
+
+## Useful commands
+
+| Command | Purpose |
+|---------|---------|
+| `docker compose up -d` | Start in detached mode |
+| `docker compose logs -f api` | Stream API logs |
+| `docker compose exec api npx prisma studio` | Open Prisma Studio (DB GUI) |
+| `docker compose exec api npx prisma migrate dev` | Create and apply a new migration |
+| `docker compose down` | Stop and remove containers |
+| `docker compose down -v` | Stop and **delete** the Postgres volume |
+
+---
+
+## Ports
+
+| Service | Host port | Container port |
+|---------|-----------|----------------|
+| API | `3000` | `3000` |
+| PostgreSQL | `5432` | `5432` |
+
+If port `5432` conflicts with a local Postgres instance, change the host-side port in `docker-compose.yml`:
+
+```yaml
+ports:
+  - '5433:5432'   # expose on host port 5433 instead
+```
+
+---
+
+## Connecting an external client to Postgres
+
+```
+Host:     localhost
+Port:     5432
+User:     mux
+Password: mux_secret
+Database: mux_db
+```
+
+---
+
+## Troubleshooting
+
+**`ECONNREFUSED` on startup** — the API starts before Postgres is ready. Docker Compose has a `healthcheck` on the `db` service and the `api` depends on it, so this should resolve automatically. If it persists, increase the `retries` value in the `db.healthcheck` block of `docker-compose.yml`.
+
+**`relation "X" does not exist`** — migrations have not been run yet. Execute `docker compose exec api npx prisma migrate deploy`.
+
+**Port already in use** — stop your local Postgres or change the host port mapping as described above.


### PR DESCRIPTION
## Summary
Adds a complete Docker Compose local development setup so contributors can spin up the full stack with a single command.

**Changes:**
- `docker-compose.yml` – PostgreSQL 16 + API services with healthcheck and `depends_on`
- `Dockerfile` – multi-stage (builder + runner) optimised for production
- `docs/DOCKER-COMPOSE-LOCAL.md` – step-by-step setup guide, port table, useful commands and troubleshooting

## Validation
- `docker compose config` validates the compose syntax
- Documentation reviewed for accuracy against `.env.example`

Closes #598