### PR TITLE
ci: lint OpenAPI spec in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,28 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      - name: Generate OpenAPI spec
+        run: pnpm run openapi:generate
+        env:
+          DATABASE_URL: postgresql://stub:stub@localhost:5432/stub
+          WALLET_ENCRYPTION_KEY: ${{ secrets.WALLET_ENCRYPTION_KEY || '0000000000000000000000000000000000000000000000000000000000000000' }}
+          STELLAR_HORIZON_URL: https://horizon-testnet.stellar.org
+          STELLAR_NETWORK: TESTNET
+          STELLAR_HORIZON_TESTNET_URL: https://horizon-testnet.stellar.org
+          STELLAR_HORIZON_MAINNET_URL: https://horizon.stellar.org
+          STELLAR_HORIZON_MAX_RETRIES: 3
+          STELLAR_HORIZON_RETRY_BACKOFF_MS: 500
+          STELLAR_HORIZON_RETRY_JITTER_MS: 250
+          BALANCE_STALE_THRESHOLD_MS: 300000
+          WEBHOOK_MAX_RETRIES: 5
+          WEBHOOK_RETRY_BACKOFF_MS: 1000
+          WEBHOOK_TIMEOUT_MS: 10000
+          WEBHOOK_MAX_CONSECUTIVE_FAILURES: 10
+          AUTH_RATE_LIMIT_MAX: 10
+          AUTH_RATE_LIMIT_WINDOW_MS: 60000
+
+      - name: Lint OpenAPI spec
+        run: pnpm run openapi:lint
+
       - name: Test
         run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ src/generated/prisma/
 # Personal notes
 vrickish.md
 somzilla.md
+
+# Generated OpenAPI spec (produced by scripts/generate-openapi.ts)
+openapi.json

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "preinstall": "npx only-allow pnpm"
+    "preinstall": "npx only-allow pnpm",
+    "openapi:generate": "ts-node -r tsconfig-paths/register scripts/generate-openapi.ts",
+    "openapi:lint": "npx @redocly/cli@latest lint openapi.json --config redocly.yaml"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,15 @@
+# Redocly OpenAPI linting configuration
+# Docs: https://redocly.com/docs/cli/configuration/
+apis:
+  main:
+    root: openapi.json
+
+rules:
+  # Enforce all operations have summaries
+  operation-summary: error
+  # Ensure every path has at least one tag
+  operation-operationId: warn
+  # No empty descriptions
+  no-empty-enum-description: warn
+  # Require info.description
+  info-description: warn

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -1,0 +1,71 @@
+/**
+ * Generates an openapi.json file from the NestJS Swagger metadata.
+ * Used by CI to lint the spec with @redocly/cli.
+ *
+ * Usage:
+ *   npx ts-node -r tsconfig-paths/register scripts/generate-openapi.ts
+ */
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Stub env before importing AppModule so validators don't throw.
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ?? 'postgresql://stub:stub@localhost:5432/stub';
+process.env.WALLET_ENCRYPTION_KEY =
+  process.env.WALLET_ENCRYPTION_KEY ?? '0'.repeat(64);
+process.env.STELLAR_HORIZON_URL =
+  process.env.STELLAR_HORIZON_URL ?? 'https://horizon-testnet.stellar.org';
+process.env.STELLAR_NETWORK = process.env.STELLAR_NETWORK ?? 'TESTNET';
+process.env.STELLAR_HORIZON_TESTNET_URL =
+  process.env.STELLAR_HORIZON_TESTNET_URL ??
+  'https://horizon-testnet.stellar.org';
+process.env.STELLAR_HORIZON_MAINNET_URL =
+  process.env.STELLAR_HORIZON_MAINNET_URL ?? 'https://horizon.stellar.org';
+process.env.STELLAR_HORIZON_MAX_RETRIES =
+  process.env.STELLAR_HORIZON_MAX_RETRIES ?? '3';
+process.env.STELLAR_HORIZON_RETRY_BACKOFF_MS =
+  process.env.STELLAR_HORIZON_RETRY_BACKOFF_MS ?? '500';
+process.env.STELLAR_HORIZON_RETRY_JITTER_MS =
+  process.env.STELLAR_HORIZON_RETRY_JITTER_MS ?? '250';
+process.env.BALANCE_STALE_THRESHOLD_MS =
+  process.env.BALANCE_STALE_THRESHOLD_MS ?? '300000';
+process.env.WEBHOOK_MAX_RETRIES = process.env.WEBHOOK_MAX_RETRIES ?? '5';
+process.env.WEBHOOK_RETRY_BACKOFF_MS =
+  process.env.WEBHOOK_RETRY_BACKOFF_MS ?? '1000';
+process.env.WEBHOOK_TIMEOUT_MS = process.env.WEBHOOK_TIMEOUT_MS ?? '10000';
+process.env.WEBHOOK_MAX_CONSECUTIVE_FAILURES =
+  process.env.WEBHOOK_MAX_CONSECUTIVE_FAILURES ?? '10';
+process.env.AUTH_RATE_LIMIT_MAX = process.env.AUTH_RATE_LIMIT_MAX ?? '10';
+process.env.AUTH_RATE_LIMIT_WINDOW_MS =
+  process.env.AUTH_RATE_LIMIT_WINDOW_MS ?? '60000';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { AppModule } = require('../src/app.module');
+
+async function generate() {
+  const app = await NestFactory.create(AppModule, { logger: false });
+  app.setGlobalPrefix('v1');
+
+  const config = new DocumentBuilder()
+    .setTitle('Mux Backend API')
+    .setDescription('Wallet, payment, and custody API for mux-backend')
+    .setVersion('1.0')
+    .addApiKey({ type: 'apiKey', in: 'header', name: 'X-API-Key' }, 'api-key')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+
+  const outPath = resolve(__dirname, '../openapi.json');
+  writeFileSync(outPath, JSON.stringify(document, null, 2));
+  console.log(`OpenAPI spec written to ${outPath}`);
+
+  await app.close();
+}
+
+generate().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Adds automated OpenAPI spec linting to CI so contract regressions are caught on every PR.

**Changes:**
- `scripts/generate-openapi.ts` – bootstraps the NestJS app (no DB needed) and writes `openapi.json`
- `redocly.yaml` – Redocly lint rules (operation summaries required, operationIds warned, etc.)
- `package.json` – `openapi:generate` and `openapi:lint` scripts
- `.github/workflows/ci.yml` – two new steps after Build: Generate OpenAPI spec → Lint OpenAPI spec
- `.gitignore` – exclude generated `openapi.json`

## Validation
- CI workflow YAML is syntactically valid
- `npx tsc --noEmit` passes on the new script file

Closes #599