### PR TITLE
feat(webhooks): optional mTLS for outbound webhook delivery

### DIFF
--- a/src/webhooks/webhook-dispatch.service.spec.ts
+++ b/src/webhooks/webhook-dispatch.service.spec.ts
@@ -1,18 +1,26 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { WebhookDispatchService } from './webhook-dispatch.service';
+import * as https from 'https';
+import {
+  WebhookDispatchService,
+  WebhookMtlsConfig,
+} from './webhook-dispatch.service';
 import { WebhookSignerService } from './webhook-signer.service';
 import { MetricsService } from '../common/metrics/metrics.service';
 import { ConfigService } from '@nestjs/config';
 import axios from 'axios';
 
 jest.mock('axios');
+jest.mock('https');
 
 describe('WebhookDispatchService', () => {
   let service: WebhookDispatchService;
   let mockSigner: any;
   let mockMetrics: any;
   let mockConfigService: any;
-  let mockAxiosInstance: { post: jest.Mock; interceptors: { request: { use: jest.Mock } } };
+  let mockAxiosInstance: {
+    post: jest.Mock;
+    interceptors: { request: { use: jest.Mock } };
+  };
 
   beforeEach(async () => {
     // Build the mock axios instance that createRequestIdAwareAxios will receive
@@ -108,9 +116,7 @@ describe('WebhookDispatchService', () => {
     });
 
     it('should handle delivery failure', async () => {
-      mockAxiosInstance.post.mockRejectedValue(
-        new Error('Connection refused'),
-      );
+      mockAxiosInstance.post.mockRejectedValue(new Error('Connection refused'));
 
       const result = await service.deliverWebhook(
         'https://example.com/webhook',
@@ -133,6 +139,140 @@ describe('WebhookDispatchService', () => {
 
       // Verify the interceptor was registered
       expect(mockAxiosInstance.interceptors.request.use).toHaveBeenCalled();
+    });
+
+    describe('mTLS support', () => {
+      const mtlsConfig: WebhookMtlsConfig = {
+        cert: '-----BEGIN CERTIFICATE-----\nSTUB\n-----END CERTIFICATE-----',
+        key: '-----BEGIN PRIVATE KEY-----\nSTUB\n-----END PRIVATE KEY-----',
+      };
+
+      it('should attach an https.Agent when mTLS config is provided', async () => {
+        mockAxiosInstance.post.mockResolvedValue({
+          status: 200,
+          data: { ok: true },
+        });
+
+        const agentSpy = jest
+          .spyOn(https, 'Agent')
+          .mockImplementation(() => ({}) as any);
+
+        await service.deliverWebhook(
+          'https://secure.example.com/webhook',
+          { event: 'test' },
+          'payment.created',
+          'evt-456',
+          'whsec_secret',
+          mtlsConfig,
+        );
+
+        // The post call should include an httpsAgent
+        const callArgs = mockAxiosInstance.post.mock.calls[0][2];
+        expect(callArgs).toHaveProperty('httpsAgent');
+
+        agentSpy.mockRestore();
+      });
+
+      it('should not attach an https.Agent when mTLS config is absent', async () => {
+        mockAxiosInstance.post.mockResolvedValue({
+          status: 200,
+          data: { ok: true },
+        });
+
+        await service.deliverWebhook(
+          'https://example.com/webhook',
+          { event: 'test' },
+          'payment.created',
+          'evt-789',
+          'whsec_secret',
+        );
+
+        const callArgs = mockAxiosInstance.post.mock.calls[0][2];
+        expect(callArgs).not.toHaveProperty('httpsAgent');
+      });
+
+      it('should pass cert and key (but not log them) to the https.Agent', async () => {
+        mockAxiosInstance.post.mockResolvedValue({
+          status: 200,
+          data: { ok: true },
+        });
+
+        const agentSpy = jest
+          .spyOn(https, 'Agent')
+          .mockImplementation(() => ({}) as any);
+
+        await service.deliverWebhook(
+          'https://secure.example.com/webhook',
+          { event: 'test' },
+          'payment.created',
+          'evt-mtls',
+          'whsec_secret',
+          mtlsConfig,
+        );
+
+        expect(agentSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cert: mtlsConfig.cert,
+            key: mtlsConfig.key,
+          }),
+        );
+
+        agentSpy.mockRestore();
+      });
+
+      it('should include optional CA cert in the https.Agent when provided', async () => {
+        mockAxiosInstance.post.mockResolvedValue({
+          status: 200,
+          data: { ok: true },
+        });
+
+        const agentSpy = jest
+          .spyOn(https, 'Agent')
+          .mockImplementation(() => ({}) as any);
+
+        const mtlsWithCa: WebhookMtlsConfig = {
+          ...mtlsConfig,
+          ca: '-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----',
+        };
+
+        await service.deliverWebhook(
+          'https://secure.example.com/webhook',
+          { event: 'test' },
+          'payment.created',
+          'evt-ca',
+          'whsec_secret',
+          mtlsWithCa,
+        );
+
+        expect(agentSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ ca: mtlsWithCa.ca }),
+        );
+
+        agentSpy.mockRestore();
+      });
+
+      it('should return success:false and not expose cert details when mTLS delivery fails', async () => {
+        mockAxiosInstance.post.mockRejectedValue(
+          Object.assign(new Error('certificate verify failed'), {
+            code: 'CERT_VERIFY_FAILED',
+          }),
+        );
+
+        const result = await service.deliverWebhook(
+          'https://secure.example.com/webhook',
+          { event: 'test' },
+          'payment.created',
+          'evt-fail',
+          'whsec_secret',
+          mtlsConfig,
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.errorMessage).toBeDefined();
+        // Cert material must not leak into error messages
+        expect(result.errorMessage).not.toContain(mtlsConfig.cert);
+        expect(result.errorMessage).not.toContain(mtlsConfig.key);
+      });
     });
   });
 

--- a/src/webhooks/webhook-dispatch.service.ts
+++ b/src/webhooks/webhook-dispatch.service.ts
@@ -1,9 +1,19 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import * as https from 'https';
 import { WebhookSignerService } from './webhook-signer.service';
 import { MetricsService } from '../common/metrics/metrics.service';
 import { createRequestIdAwareAxios } from '../common/http/request-id-axios';
 import { AxiosError } from 'axios';
+
+export interface WebhookMtlsConfig {
+  /** PEM-encoded client certificate */
+  cert: string;
+  /** PEM-encoded client private key */
+  key: string;
+  /** Optional PEM-encoded CA certificate to verify the server */
+  ca?: string;
+}
 
 export interface WebhookDispatchResult {
   success: boolean;
@@ -19,7 +29,11 @@ export interface WebhookDispatchResult {
  * Responsible only for:
  * - Building the webhook payload
  * - Signing the payload
- * - Making the outbound HTTP call
+ * - Making the outbound HTTP call (with optional mTLS)
+ *
+ * mTLS is opt-in per delivery: pass a {@link WebhookMtlsConfig} to enable
+ * mutual TLS for endpoints that require client certificate authentication.
+ * Cert/key material is never written to logs.
  */
 @Injectable()
 export class WebhookDispatchService {
@@ -39,23 +53,45 @@ export class WebhookDispatchService {
   }
 
   /**
-   * Attempts to deliver a webhook payload to an endpoint
+   * Attempts to deliver a webhook payload to an endpoint.
+   *
+   * @param url        Target endpoint URL
+   * @param payload    JSON-serialisable body
+   * @param eventType  Webhook event type string (e.g. "wallet.created")
+   * @param eventId    Unique event identifier
+   * @param secret     HMAC signing secret
+   * @param mtls       Optional mTLS client certificate configuration.
+   *                   When provided, a dedicated HTTPS agent presenting the
+   *                   client cert is attached to this request only.
+   *                   The cert and key values are never logged.
    */
   async deliverWebhook(
     url: string,
-    payload: any,
+    payload: unknown,
     eventType: string,
     eventId: string,
     secret: string,
+    mtls?: WebhookMtlsConfig,
   ): Promise<WebhookDispatchResult> {
     const startTime = Date.now();
 
-    this.logger.log(`Delivering webhook to ${url} (event: ${eventType})`);
+    this.logger.log(
+      `Delivering webhook to ${url} (event: ${eventType}, mtls: ${mtls ? 'enabled' : 'disabled'})`,
+    );
 
     try {
       // Sign the payload
       const { timestamp, signature } =
         this.webhookSigner.generateSignatureHeaders(payload, secret);
+
+      // Build optional mTLS HTTPS agent
+      const httpsAgent = mtls
+        ? new https.Agent({
+            cert: mtls.cert,
+            key: mtls.key,
+            ...(mtls.ca ? { ca: mtls.ca } : {}),
+          })
+        : undefined;
 
       // Make HTTP request (x-request-id is automatically propagated)
       const response = await this.http.post(url, payload, {
@@ -71,6 +107,7 @@ export class WebhookDispatchService {
         },
         timeout: this.requestTimeoutMs,
         validateStatus: (status) => status >= 200 && status < 300,
+        ...(httpsAgent ? { httpsAgent } : {}),
       });
 
       const responseTime = Date.now() - startTime;
@@ -92,9 +129,7 @@ export class WebhookDispatchService {
         ? JSON.stringify(axiosError.response.data).substring(0, 500)
         : axiosError.message;
 
-      this.logger.warn(
-        `Webhook delivery failed: ${axiosError.message}`,
-      );
+      this.logger.warn(`Webhook delivery failed: ${axiosError.message}`);
 
       return {
         success: false,


### PR DESCRIPTION
## Summary
Adds opt-in mutual TLS (mTLS) to outbound webhook delivery so endpoints that require client certificate authentication are supported without affecting existing non-mTLS endpoints.

**Changes:**
- `src/webhooks/webhook-dispatch.service.ts`
  - New `WebhookMtlsConfig` interface: `{ cert, key, ca? }`
  - Optional 6th parameter `mtls?: WebhookMtlsConfig` on `deliverWebhook()`
  - When present, an `https.Agent` carrying the client certificate is attached to that request only — no global agent mutation
  - Cert/key material is never logged (only event type, URL, success/failure are logged)
- `src/webhooks/webhook-dispatch.service.spec.ts`
  - 5 new mTLS-specific tests: agent attached when config provided, not attached when absent, cert+key passed to Agent, CA cert forwarded, failure path with no secret leakage

## Validation
- `npx tsc --noEmit` → 0 errors in webhooks module
- `npx jest --testPathPatterns='webhook-dispatch.service'` → 13/13 passing

Closes #600