### PR TITLE
Add webhook signature verification tests

### DIFF
--- a/src/webhooks/webhook-signature.guard.spec.ts
+++ b/src/webhooks/webhook-signature.guard.spec.ts
@@ -1,0 +1,274 @@
+import { ExecutionContext, HttpException, HttpStatus } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  WebhookSignatureGuard,
+  WEBHOOK_SIGNATURE_HEADER,
+} from './webhook-signature.guard';
+import { WebhookSignerService } from './webhook-signer.service';
+
+describe('WebhookSignatureGuard', () => {
+  let guard: WebhookSignatureGuard;
+  let signer: WebhookSignerService;
+  let configService: jest.Mocked<ConfigService>;
+
+  const secret = 'test-inbound-secret';
+
+  beforeEach(() => {
+    signer = new WebhookSignerService();
+    configService = {
+      get: jest.fn().mockReturnValue(secret),
+    } as unknown as jest.Mocked<ConfigService>;
+    guard = new WebhookSignatureGuard(signer, configService);
+  });
+
+  const makeCtx = (
+    headers: Record<string, string | string[] | undefined>,
+    body: unknown,
+  ): ExecutionContext => {
+    const request = {
+      headers,
+      body,
+      method: 'POST',
+      path: '/webhooks/inbound',
+    };
+    return {
+      switchToHttp: () => ({ getRequest: () => request }),
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+    } as unknown as ExecutionContext;
+  };
+
+  const sign = (payload: unknown, ts: number) => {
+    const payloadString = JSON.stringify(payload);
+    const signature = signer.signPayload(payloadString, secret, ts);
+    return signer.formatSignatureHeader(ts, signature);
+  };
+
+  // ---------------------------------------------------------------------------
+  // Success path — valid signature is accepted
+  // ---------------------------------------------------------------------------
+
+  it('should allow the request through when the signature is valid', () => {
+    const body = { event: 'wallet.created', id: 'evt-1' };
+    const ts = Math.floor(Date.now() / 1000);
+    const header = sign(body, ts);
+
+    const ctx = makeCtx({ [WEBHOOK_SIGNATURE_HEADER]: header }, body);
+
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('should verify against the raw body when present, not the parsed body', () => {
+    const rawPayload = '{"event":"wallet.created","id":"evt-1"}';
+    const ts = Math.floor(Date.now() / 1000);
+    const signature = signer.signPayload(rawPayload, secret, ts);
+    const header = signer.formatSignatureHeader(ts, signature);
+
+    const request = {
+      headers: { [WEBHOOK_SIGNATURE_HEADER]: header },
+      body: { event: 'wallet.created', id: 'evt-1' },
+      rawBody: Buffer.from(rawPayload, 'utf8'),
+      method: 'POST',
+      path: '/webhooks/inbound',
+    };
+    const ctx = {
+      switchToHttp: () => ({ getRequest: () => request }),
+      getHandler: jest.fn(),
+      getClass: jest.fn(),
+    } as unknown as ExecutionContext;
+
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Failure path — missing signature header
+  // ---------------------------------------------------------------------------
+
+  it('should reject with 401 when the signature header is missing', () => {
+    const ctx = makeCtx({}, { event: 'wallet.created' });
+
+    expect(() => guard.canActivate(ctx)).toThrow(HttpException);
+
+    try {
+      guard.canActivate(ctx);
+      fail('expected canActivate to throw');
+    } catch (e) {
+      const err = e as HttpException;
+      expect(err.getStatus()).toBe(HttpStatus.UNAUTHORIZED);
+      expect(err.getResponse()).toEqual({
+        statusCode: HttpStatus.UNAUTHORIZED,
+        message: 'Invalid webhook signature',
+        error: 'Unauthorized',
+      });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Failure path — malformed signature header
+  // ---------------------------------------------------------------------------
+
+  it('should reject with 401 when the signature header is malformed', () => {
+    const ctx = makeCtx(
+      { [WEBHOOK_SIGNATURE_HEADER]: 'not-a-valid-header' },
+      { event: 'wallet.created' },
+    );
+
+    expect(() => guard.canActivate(ctx)).toThrow(HttpException);
+    try {
+      guard.canActivate(ctx);
+      fail('expected canActivate to throw');
+    } catch (e) {
+      expect((e as HttpException).getStatus()).toBe(HttpStatus.UNAUTHORIZED);
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Failure path — tampered payload (body changed after signing)
+  // ---------------------------------------------------------------------------
+
+  it('should reject with 401 when the body was tampered with after signing', () => {
+    const originalBody = { event: 'wallet.created', amount: 100 };
+    const ts = Math.floor(Date.now() / 1000);
+    const header = sign(originalBody, ts);
+
+    const tamperedBody = { event: 'wallet.created', amount: 999999 };
+    const ctx = makeCtx({ [WEBHOOK_SIGNATURE_HEADER]: header }, tamperedBody);
+
+    expect(() => guard.canActivate(ctx)).toThrow(HttpException);
+    try {
+      guard.canActivate(ctx);
+      fail('expected canActivate to throw');
+    } catch (e) {
+      const err = e as HttpException;
+      expect(err.getStatus()).toBe(HttpStatus.UNAUTHORIZED);
+      expect(err.getResponse()).toEqual({
+        statusCode: HttpStatus.UNAUTHORIZED,
+        message: 'Invalid webhook signature',
+        error: 'Unauthorized',
+      });
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Failure path — signature signed with the wrong secret
+  // ---------------------------------------------------------------------------
+
+  it('should reject with 401 when signed with an incorrect secret', () => {
+    const body = { event: 'wallet.created' };
+    const ts = Math.floor(Date.now() / 1000);
+    const payloadString = JSON.stringify(body);
+    const wrongSignature = signer.signPayload(
+      payloadString,
+      'wrong-secret',
+      ts,
+    );
+    const header = signer.formatSignatureHeader(ts, wrongSignature);
+
+    const ctx = makeCtx({ [WEBHOOK_SIGNATURE_HEADER]: header }, body);
+
+    expect(() => guard.canActivate(ctx)).toThrow(HttpException);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Failure path — expired / stale timestamp (replay protection)
+  // ---------------------------------------------------------------------------
+
+  it('should reject with 401 when the signature timestamp is too old', () => {
+    const body = { event: 'wallet.created' };
+    const staleTs = Math.floor(Date.now() / 1000) - 600; // 10 minutes ago
+    const header = sign(body, staleTs);
+
+    const ctx = makeCtx({ [WEBHOOK_SIGNATURE_HEADER]: header }, body);
+
+    expect(() => guard.canActivate(ctx)).toThrow(HttpException);
+    try {
+      guard.canActivate(ctx);
+      fail('expected canActivate to throw');
+    } catch (e) {
+      expect((e as HttpException).getStatus()).toBe(HttpStatus.UNAUTHORIZED);
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Consistent error shape across every failure reason
+  // ---------------------------------------------------------------------------
+
+  it('should return the same error response shape for every rejection reason', () => {
+    const body = { event: 'wallet.created' };
+    const ts = Math.floor(Date.now() / 1000);
+
+    const scenarios: Array<{
+      headers: Record<string, string | string[] | undefined>;
+      body: unknown;
+    }> = [
+      { headers: {}, body }, // missing header
+      { headers: { [WEBHOOK_SIGNATURE_HEADER]: 'garbage' }, body }, // malformed
+      { headers: { [WEBHOOK_SIGNATURE_HEADER]: sign(body, ts) }, body: { event: 'tampered' } }, // tampered
+    ];
+
+    const responses = scenarios.map((s) => {
+      const ctx = makeCtx(s.headers, s.body);
+      try {
+        guard.canActivate(ctx);
+        return undefined;
+      } catch (e) {
+        return (e as HttpException).getResponse();
+      }
+    });
+
+    expect(responses).toEqual([
+      {
+        statusCode: HttpStatus.UNAUTHORIZED,
+        message: 'Invalid webhook signature',
+        error: 'Unauthorized',
+      },
+      {
+        statusCode: HttpStatus.UNAUTHORIZED,
+        message: 'Invalid webhook signature',
+        error: 'Unauthorized',
+      },
+      {
+        statusCode: HttpStatus.UNAUTHORIZED,
+        message: 'Invalid webhook signature',
+        error: 'Unauthorized',
+      },
+    ]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fail closed when the inbound secret is not configured
+  // ---------------------------------------------------------------------------
+
+  it('should fail closed with 500 when WEBHOOK_INBOUND_SECRET is not configured', () => {
+    configService.get.mockReturnValue(undefined);
+    const body = { event: 'wallet.created' };
+    const ts = Math.floor(Date.now() / 1000);
+    const header = sign(body, ts);
+
+    const ctx = makeCtx({ [WEBHOOK_SIGNATURE_HEADER]: header }, body);
+
+    expect(() => guard.canActivate(ctx)).toThrow(HttpException);
+    try {
+      guard.canActivate(ctx);
+      fail('expected canActivate to throw');
+    } catch (e) {
+      expect((e as HttpException).getStatus()).toBe(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Header value provided as an array (some proxies duplicate headers)
+  // ---------------------------------------------------------------------------
+
+  it('should use the first value when the signature header is duplicated as an array', () => {
+    const body = { event: 'wallet.created' };
+    const ts = Math.floor(Date.now() / 1000);
+    const header = sign(body, ts);
+
+    const ctx = makeCtx({ [WEBHOOK_SIGNATURE_HEADER]: [header, header] }, body);
+
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+});

--- a/src/webhooks/webhook-signature.guard.ts
+++ b/src/webhooks/webhook-signature.guard.ts
@@ -1,0 +1,113 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { ConfigService } from '@nestjs/config';
+import { WebhookSignerService } from './webhook-signer.service';
+
+export const WEBHOOK_SIGNATURE_HEADER = 'x-webhook-signature';
+
+/**
+ * WebhookSignatureGuard
+ *
+ * Verifies the HMAC-SHA256 signature of an inbound webhook request against
+ * a shared secret, using the same `t=<ts>,v1=<sig>` header format produced
+ * by {@link WebhookSignerService.formatSignatureHeader}.
+ *
+ * This guard DOES NOT authenticate callers by identity — it only proves the
+ * request body was signed by a holder of the configured secret and was not
+ * tampered with in transit (and is not a stale replay).
+ *
+ * All rejections use the same response shape so callers get a consistent,
+ * predictable error contract regardless of *why* verification failed
+ * (missing header, malformed header, wrong secret, tampered body, expired
+ * timestamp):
+ *
+ *   { statusCode: 401, message: 'Invalid webhook signature', error: 'Unauthorized' }
+ *
+ * Usage:
+ *   @UseGuards(WebhookSignatureGuard)
+ *   @Post('inbound')
+ *   async receive(@Body() body: unknown) { ... }
+ *
+ * The signing secret is read from the `WEBHOOK_INBOUND_SECRET` environment
+ * variable. If it is not configured, the guard fails closed (500) rather
+ * than silently accepting unsigned requests.
+ */
+@Injectable()
+export class WebhookSignatureGuard implements CanActivate {
+  private readonly logger = new Logger(WebhookSignatureGuard.name);
+
+  constructor(
+    private readonly webhookSigner: WebhookSignerService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+
+    const secret = this.configService.get<string>('WEBHOOK_INBOUND_SECRET');
+    if (!secret) {
+      this.logger.error(
+        'WEBHOOK_INBOUND_SECRET is not configured; refusing to verify inbound webhook',
+      );
+      throw new HttpException(
+        {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: 'Webhook verification is not configured',
+          error: 'Internal Server Error',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+
+    const header = request.headers?.[WEBHOOK_SIGNATURE_HEADER];
+    const headerValue = Array.isArray(header) ? header[0] : header;
+
+    if (!headerValue) {
+      this.logger.warn('Rejected webhook: missing signature header');
+      throw this.unauthorized();
+    }
+
+    const parsed = this.webhookSigner.parseSignatureHeader(headerValue);
+    if (!parsed || Number.isNaN(parsed.timestamp)) {
+      this.logger.warn('Rejected webhook: malformed signature header');
+      throw this.unauthorized();
+    }
+
+    const rawBody = (request as unknown as { rawBody?: Buffer }).rawBody;
+    const payload = rawBody
+      ? rawBody.toString('utf8')
+      : JSON.stringify(request.body ?? {});
+
+    const isValid = this.webhookSigner.verifySignature(
+      payload,
+      parsed.signature,
+      secret,
+      parsed.timestamp,
+    );
+
+    if (!isValid) {
+      this.logger.warn('Rejected webhook: invalid or expired signature');
+      throw this.unauthorized();
+    }
+
+    return true;
+  }
+
+  private unauthorized(): HttpException {
+    return new HttpException(
+      {
+        statusCode: HttpStatus.UNAUTHORIZED,
+        message: 'Invalid webhook signature',
+        error: 'Unauthorized',
+      },
+      HttpStatus.UNAUTHORIZED,
+    );
+  }
+}

--- a/src/webhooks/webhook-signer.service.spec.ts
+++ b/src/webhooks/webhook-signer.service.spec.ts
@@ -97,6 +97,106 @@ describe('WebhookSignerService', () => {
 
       expect(isValid).toBe(false);
     });
+
+    it('should reject a tampered payload even with a structurally valid signature', () => {
+      const secret = 'test-secret';
+      const timestamp = Math.floor(Date.now() / 1000);
+      const originalPayload = JSON.stringify({ amount: 100 });
+      const tamperedPayload = JSON.stringify({ amount: 999999 });
+
+      // Signature was computed over the original payload...
+      const signature = service.signPayload(
+        originalPayload,
+        secret,
+        timestamp,
+      );
+
+      // ...but the attacker sends a different payload with that signature.
+      const isValid = service.verifySignature(
+        tamperedPayload,
+        signature,
+        secret,
+        timestamp,
+      );
+
+      expect(isValid).toBe(false);
+    });
+
+    it('should reject when signed with the wrong secret', () => {
+      const payload = JSON.stringify({ test: 'data' });
+      const timestamp = Math.floor(Date.now() / 1000);
+
+      const signature = service.signPayload(
+        payload,
+        'correct-secret',
+        timestamp,
+      );
+      const isValid = service.verifySignature(
+        payload,
+        signature,
+        'wrong-secret',
+        timestamp,
+      );
+
+      expect(isValid).toBe(false);
+    });
+
+    it('should reject signatures of a different length without throwing', () => {
+      const payload = JSON.stringify({ test: 'data' });
+      const secret = 'test-secret';
+      const timestamp = Math.floor(Date.now() / 1000);
+
+      expect(() =>
+        service.verifySignature(payload, 'short', secret, timestamp),
+      ).not.toThrow();
+      expect(
+        service.verifySignature(payload, 'short', secret, timestamp),
+      ).toBe(false);
+    });
+
+    it('should reject empty-string signatures', () => {
+      const payload = JSON.stringify({ test: 'data' });
+      const secret = 'test-secret';
+      const timestamp = Math.floor(Date.now() / 1000);
+
+      expect(
+        service.verifySignature(payload, '', secret, timestamp),
+      ).toBe(false);
+    });
+
+    it('should reject timestamps too far in the future (clock skew abuse)', () => {
+      const payload = JSON.stringify({ test: 'data' });
+      const secret = 'test-secret';
+      const futureTimestamp = Math.floor(Date.now() / 1000) + 600; // 10 min ahead
+
+      const signature = service.signPayload(payload, secret, futureTimestamp);
+      const isValid = service.verifySignature(
+        payload,
+        signature,
+        secret,
+        futureTimestamp,
+        300,
+      );
+
+      expect(isValid).toBe(false);
+    });
+
+    it('should accept a signature at the edge of the tolerance window', () => {
+      const payload = JSON.stringify({ test: 'data' });
+      const secret = 'test-secret';
+      const timestamp = Math.floor(Date.now() / 1000) - 299; // just inside 300s
+
+      const signature = service.signPayload(payload, secret, timestamp);
+      const isValid = service.verifySignature(
+        payload,
+        signature,
+        secret,
+        timestamp,
+        300,
+      );
+
+      expect(isValid).toBe(true);
+    });
   });
 
   describe('formatSignatureHeader', () => {
@@ -128,6 +228,70 @@ describe('WebhookSignerService', () => {
       const result = service.parseSignatureHeader(header);
 
       expect(result).toBeNull();
+    });
+
+    it('should return null when the header is an empty string', () => {
+      const result = service.parseSignatureHeader('');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when the timestamp component is missing', () => {
+      const header = 'v1=abcdef123456';
+
+      const result = service.parseSignatureHeader(header);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when the signature component is missing', () => {
+      const header = 't=1234567890';
+
+      const result = service.parseSignatureHeader(header);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('end-to-end sign + verify', () => {
+    it('should accept a signature generated via generateSignatureHeaders and formatSignatureHeader', () => {
+      const secret = 'test-secret';
+      const payload = { walletId: 'wallet-1', amount: 42 };
+
+      const { timestamp, signature } = service.generateSignatureHeaders(
+        payload,
+        secret,
+      );
+      const header = service.formatSignatureHeader(timestamp, signature);
+      const parsed = service.parseSignatureHeader(header);
+
+      expect(parsed).not.toBeNull();
+      const isValid = service.verifySignature(
+        JSON.stringify(payload),
+        parsed!.signature,
+        secret,
+        parsed!.timestamp,
+      );
+
+      expect(isValid).toBe(true);
+    });
+
+    it('should reject when the receiver uses a different secret than the sender', () => {
+      const payload = { walletId: 'wallet-1', amount: 42 };
+
+      const { timestamp, signature } = service.generateSignatureHeaders(
+        payload,
+        'sender-secret',
+      );
+
+      const isValid = service.verifySignature(
+        JSON.stringify(payload),
+        signature,
+        'receiver-secret',
+        timestamp,
+      );
+
+      expect(isValid).toBe(false);
     });
   });
 });

--- a/src/webhooks/webhook.module.ts
+++ b/src/webhooks/webhook.module.ts
@@ -5,6 +5,7 @@ import { WebhookDispatcherService } from './webhook-dispatcher.service';
 import { WebhookDispatchService } from './webhook-dispatch.service';
 import { WebhookRetryService } from './webhook-retry.service';
 import { WebhookSignerService } from './webhook-signer.service';
+import { WebhookSignatureGuard } from './webhook-signature.guard';
 import { WebhookEventEmitterService } from './webhook-event-emitter.service';
 import { WebhookDeliveryQueueWorker } from './webhook-delivery-queue.worker';
 import { WebhookController } from './webhook.controller';
@@ -25,6 +26,7 @@ import { FeatureFlagGuard } from '../common/feature-flags/feature-flag.guard';
     WebhookDispatchService,
     WebhookRetryService,
     WebhookSignerService,
+    WebhookSignatureGuard,
     WebhookEventEmitterService,
     WebhookDeliveryQueueWorker,
     MetricsService,


### PR DESCRIPTION
## Summary
Adds focused unit test coverage for webhook signature verification so that wallet/payment/custody event delivery stays reliable for frontend and partner integrations. Also adds a minimal `WebhookSignatureGuard` (with its own test suite) that verifies inbound webhook signatures against a shared secret and returns a consistent `401 Unauthorized` error shape regardless of failure reason.

## Context / Before-After
**Before:** `webhook-signer.service.spec.ts` covered only the happy path, a basic invalid-signature case, and replay protection for old timestamps. There was no coverage for tampered payloads, wrong-secret signing, malformed/partial signature headers, future-timestamp abuse, or the tolerance-window boundary. There was also no reusable guard/consistent error contract for verifying an *inbound* webhook signature at the HTTP layer.

**After:**
- `webhook-signer.service.spec.ts` gains tests for: tampered payload rejection, wrong-secret rejection, mismatched-length/empty signature handling (no throw), future-timestamp rejection, tolerance-window edge case, malformed `parseSignatureHeader` inputs (missing `t=`/`v1=` components, empty string), and an end-to-end sign → format → parse → verify round trip.
- New `WebhookSignatureGuard` (`src/webhooks/webhook-signature.guard.ts`) verifies the `x-webhook-signature` header using the existing `WebhookSignerService`, fails closed with `500` if no secret is configured, and always returns the same `{ statusCode: 401, message: 'Invalid webhook signature', error: 'Unauthorized' }` shape for missing header, malformed header, wrong secret, tampered body, or expired timestamp.
- New `webhook-signature.guard.spec.ts` covers: valid signature accepted, raw-body vs parsed-body verification, missing header, malformed header, tampered payload, wrong secret, expired timestamp, duplicated header values, and a dedicated test asserting the error response shape is identical across all rejection reasons.

No public API/OpenAPI contract changes — the guard is registered as a provider in `webhook.module.ts` but is not yet wired to a route, so this is test/coverage-only from an external-behavior standpoint.

## Testing
`pnpm install` was not run in this environment per task constraints (node_modules is intentionally absent here), so these tests were written and reviewed carefully against existing conventions but **not executed locally**. Please run `pnpm test` in CI/locally to verify:

```
pnpm test -- webhook-signer.service.spec.ts webhook-signature.guard.spec.ts
```

Closes #559
