### PR TITLE
Block delete when transactions are pending

### DIFF
--- a/src/wallets/wallets.controller.ts
+++ b/src/wallets/wallets.controller.ts
@@ -304,6 +304,13 @@ export class WalletsController {
 
   @ApiOperation({ summary: 'Delete a wallet' })
   @ApiParam({ name: 'id', description: 'Wallet ID' })
+  @ApiResponse({ status: 200, description: 'Wallet deleted' })
+  @ApiResponse({ status: 404, description: 'Wallet not found' })
+  @ApiResponse({
+    status: 409,
+    description:
+      'Wallet has pending (PENDING/SUBMITTED) transactions and cannot be deleted',
+  })
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.walletsService.remove(id);

--- a/src/wallets/wallets.service.spec.ts
+++ b/src/wallets/wallets.service.spec.ts
@@ -1,7 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import { WalletsService, CreateWalletRequest } from './wallets.service';
 import { WalletNetwork, WalletStatus } from './domain/wallet.model';
+import { TransactionStatus } from '../transactions/domain/transaction.model';
 import {
   EncryptionService,
   DecryptionError,
@@ -30,6 +32,11 @@ const mockPrismaUser = {
   update: jest.fn(),
 };
 
+// Shared mock Prisma transaction methods (used by the pending-delete guard)
+const mockPrismaTransactionModel = {
+  count: jest.fn(),
+};
+
 // $transaction mock – executes the callback and passes the wallet mock as the tx client
 const mockPrismaTransaction = jest.fn(async (cb: (tx: any) => Promise<any>) =>
   cb({ wallet: mockPrismaWallet }),
@@ -40,6 +47,7 @@ jest.mock('../generated/prisma/client', () => ({
   PrismaClient: jest.fn(() => ({
     wallet: mockPrismaWallet,
     user: mockPrismaUser,
+    transaction: mockPrismaTransactionModel,
     $transaction: mockPrismaTransaction,
   })),
 }));
@@ -857,6 +865,78 @@ describe('WalletsService', () => {
       ).rejects.toThrow('User with ID missing-user not found');
 
       expect(mockPrismaUser.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remove', () => {
+    const existingWallet = {
+      id: 'wallet-123',
+      userId: 'user-123',
+      publicKey: 'GABC123',
+      encryptedSecret: 'secret',
+      encryptionVersion: 1,
+      secretVersion: 1,
+      keyVersion: 1,
+      network: WalletNetwork.TESTNET,
+      status: 'ACTIVE',
+      statusReason: null,
+      statusChangedAt: new Date(),
+      rotatedFromId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('deletes the wallet when there are no pending transactions', async () => {
+      mockPrismaWallet.findUnique.mockResolvedValue(existingWallet);
+      mockPrismaTransactionModel.count.mockResolvedValue(0);
+      mockPrismaWallet.delete.mockResolvedValue(existingWallet);
+
+      const result = await service.remove('wallet-123');
+
+      expect(mockPrismaTransactionModel.count).toHaveBeenCalledWith({
+        where: {
+          OR: [
+            { senderWalletId: 'wallet-123' },
+            { receiverWalletId: 'wallet-123' },
+          ],
+          status: {
+            in: [TransactionStatus.PENDING, TransactionStatus.SUBMITTED],
+          },
+        },
+      });
+      expect(mockPrismaWallet.delete).toHaveBeenCalledWith({
+        where: { id: 'wallet-123' },
+      });
+      expect(result.id).toBe('wallet-123');
+      expect(result).not.toHaveProperty('encryptedSecret');
+    });
+
+    it('blocks deletion with a ConflictException when pending transactions exist', async () => {
+      mockPrismaWallet.findUnique.mockResolvedValue(existingWallet);
+      mockPrismaTransactionModel.count.mockResolvedValue(2);
+
+      await expect(service.remove('wallet-123')).rejects.toThrow(
+        ConflictException,
+      );
+      await expect(service.remove('wallet-123')).rejects.toThrow(
+        'Cannot delete wallet wallet-123: 2 pending transaction(s) must settle first',
+      );
+
+      expect(mockPrismaWallet.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException if the wallet does not exist', async () => {
+      mockPrismaWallet.findUnique.mockResolvedValue(null);
+
+      await expect(service.remove('missing-wallet')).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(service.remove('missing-wallet')).rejects.toThrow(
+        'Wallet with ID missing-wallet not found',
+      );
+
+      expect(mockPrismaTransactionModel.count).not.toHaveBeenCalled();
+      expect(mockPrismaWallet.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/wallets/wallets.service.ts
+++ b/src/wallets/wallets.service.ts
@@ -30,6 +30,7 @@ import {
   StructuredLogger,
   LogContext,
 } from '../common/logging/structured-logger';
+import { TransactionStatus } from '../transactions/domain/transaction.model';
 
 /** Wallet shape safe to return from the API (no encrypted secret material). */
 export type PublicWallet = Omit<Wallet, 'encryptedSecret'>;
@@ -618,8 +619,57 @@ export class WalletsService implements OnModuleDestroy {
     return this.toPublicWallet(this.mapPrismaWalletToDomain(updated));
   }
 
-  remove(id: string) {
-    return this.prisma.wallet.delete({ where: { id } });
+  /**
+   * Deletes a wallet, guarding against removal while transactions are still
+   * in flight.
+   *
+   * #558: A wallet with PENDING or SUBMITTED transactions (sent or received)
+   * must not be deleted — the underlying transaction record would be left
+   * referencing a wallet that no longer exists, and any in-progress Stellar
+   * submission/settlement could silently lose its owning wallet context.
+   * Only wallets whose transactions have all reached a terminal state
+   * (CONFIRMED / FAILED) — or that have none at all — may be deleted.
+   */
+  async remove(id: string): Promise<PublicWallet> {
+    const wallet = await this.prisma.wallet.findUnique({ where: { id } });
+    if (!wallet) {
+      throw new NotFoundException(`Wallet with ID ${id} not found`);
+    }
+
+    const pendingTransactionCount = await this.prisma.transaction.count({
+      where: {
+        OR: [{ senderWalletId: id }, { receiverWalletId: id }],
+        status: {
+          in: [TransactionStatus.PENDING, TransactionStatus.SUBMITTED],
+        },
+      },
+    });
+
+    if (pendingTransactionCount > 0) {
+      this.logger.logWithContext(
+        'Blocked wallet deletion: pending transactions exist',
+        {
+          operation: 'remove',
+          entityType: 'wallet',
+          entityId: id,
+          outcome: 'blocked',
+        },
+      );
+      throw new ConflictException(
+        `Cannot delete wallet ${id}: ${pendingTransactionCount} pending transaction(s) must settle first`,
+      );
+    }
+
+    const deleted = await this.prisma.wallet.delete({ where: { id } });
+
+    this.logger.logWithContext('Deleted wallet', {
+      operation: 'remove',
+      entityType: 'wallet',
+      entityId: id,
+      outcome: 'success',
+    });
+
+    return this.toPublicWallet(this.mapPrismaWalletToDomain(deleted));
   }
 
   async archive(id: string, reason?: string): Promise<PublicWallet> {


### PR DESCRIPTION
## Summary

Adds a guard to `WalletsService.remove()` so a wallet cannot be deleted while it has in-flight transactions. Before deleting, the service now counts `PENDING`/`SUBMITTED` transactions where the wallet is either sender or receiver, and rejects the delete if any exist. This prevents wallet/payment/custody flows from orphaning transaction records or losing context on transactions that are still being processed on-chain.

## Context / Before-After

**Before:** `DELETE /wallets/:id` called `prisma.wallet.delete()` unconditionally. A wallet with active transactions could be deleted, leaving those transaction rows referencing a non-existent wallet and risking inconsistent state for payment/custody consumers.

**After:** `remove()` first verifies the wallet exists (404 `NotFoundException` if not), then counts pending (`PENDING`/`SUBMITTED`) transactions tied to the wallet. If any are found, it throws a `ConflictException` (409, normalized by the existing global `HttpExceptionFilter` into the standard error response shape — not a 500). Only when no pending transactions remain does the delete proceed, and the response omits `encryptedSecret` like other wallet endpoints. Swagger docs for the route were updated to document the 404/409 cases.

## Testing

`pnpm install` was not run in this environment per task constraints (node_modules is intentionally absent here), so the added/updated unit tests in `src/wallets/wallets.service.spec.ts` were written and reviewed against existing test conventions in the file but not executed locally. Please run `pnpm test` in CI or locally to verify:
- delete succeeds and returns the wallet (without `encryptedSecret`) when there are no pending transactions
- delete is blocked with a `ConflictException` when pending transactions exist
- delete returns `NotFoundException` when the wallet does not exist

Closes #558
