### PR TITLE
Accept client version header for support logs

### DIFF
--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -54,6 +54,14 @@ async function generate() {
     .setDescription('Wallet, payment, and custody API for mux-backend')
     .setVersion('1.0')
     .addApiKey({ type: 'apiKey', in: 'header', name: 'X-API-Key' }, 'api-key')
+    .addGlobalParameters({
+      name: 'X-Client-Version',
+      in: 'header',
+      required: false,
+      description:
+        'Optional client application version (e.g. "2.4.1"). Included in support logs to help triage wallet/payment/custody issues by reporting client version. Missing or malformed values are ignored and do not affect the request.',
+      schema: { type: 'string' },
+    })
     .build();
 
   const document = SwaggerModule.createDocument(app, config);

--- a/src/common/middleware/request-logging.middleware.spec.ts
+++ b/src/common/middleware/request-logging.middleware.spec.ts
@@ -1,4 +1,6 @@
-import requestLogger from './request-logging.middleware';
+import requestLogger, {
+  extractClientVersion,
+} from './request-logging.middleware';
 import { Logger } from '@nestjs/common';
 import { RequestContextService } from '../request-context/request-context.service';
 
@@ -156,5 +158,114 @@ describe('requestLogger', () => {
     expect(next).toHaveBeenCalled();
     expect(capturedRequestId).toBeDefined();
     expect(capturedRequestId).toBe(req.requestId);
+  });
+
+  describe('X-Client-Version header', () => {
+    it('extractClientVersion returns a trimmed value when the header is present and well-formed', () => {
+      const req: any = { headers: { 'x-client-version': '  2.4.1  ' } };
+      expect(extractClientVersion(req)).toBe('2.4.1');
+    });
+
+    it('extractClientVersion returns undefined when the header is absent', () => {
+      const req: any = { headers: {} };
+      expect(extractClientVersion(req)).toBeUndefined();
+    });
+
+    it('extractClientVersion returns undefined for an empty header value', () => {
+      const req: any = { headers: { 'x-client-version': '   ' } };
+      expect(extractClientVersion(req)).toBeUndefined();
+    });
+
+    it('extractClientVersion returns undefined for a malformed/unsafe header value', () => {
+      const req: any = {
+        headers: { 'x-client-version': 'bad value\nwith-newline' },
+      };
+      expect(extractClientVersion(req)).toBeUndefined();
+    });
+
+    it('extractClientVersion returns undefined for an over-long header value', () => {
+      const req: any = { headers: { 'x-client-version': 'v'.repeat(200) } };
+      expect(extractClientVersion(req)).toBeUndefined();
+    });
+
+    it('extractClientVersion handles a request with no headers object gracefully', () => {
+      const req: any = null;
+      expect(extractClientVersion(req)).toBeUndefined();
+    });
+
+    it('captures a present client version on the request and in the log context', () => {
+      const req: any = {
+        method: 'GET',
+        originalUrl: '/test',
+        headers: { 'x-client-version': '3.1.0' },
+        ip: '1.2.3.4',
+      };
+      const res: any = { setHeader: jest.fn(), on: jest.fn(), statusCode: 200 };
+
+      let capturedClientVersion: string | undefined;
+      const next = jest.fn().mockImplementation(() => {
+        const service = new RequestContextService();
+        capturedClientVersion = service.getClientVersion();
+      });
+
+      const spyLog = jest
+        .spyOn(Logger.prototype, 'log')
+        .mockImplementation(() => {});
+
+      requestLogger(req, res, next as any);
+
+      expect(req.clientVersion).toBe('3.1.0');
+      expect(next).toHaveBeenCalled();
+      expect(capturedClientVersion).toBe('3.1.0');
+      expect(spyLog).toHaveBeenCalledWith(
+        expect.stringContaining('clientVersion=3.1.0'),
+      );
+    });
+
+    it('omits the client version and still processes the request when the header is missing', () => {
+      const req: any = {
+        method: 'GET',
+        originalUrl: '/test',
+        headers: {},
+        ip: '1.2.3.4',
+      };
+      const res: any = { setHeader: jest.fn(), on: jest.fn(), statusCode: 200 };
+
+      let capturedClientVersion: string | undefined = 'unset';
+      const next = jest.fn().mockImplementation(() => {
+        const service = new RequestContextService();
+        capturedClientVersion = service.getClientVersion();
+      });
+
+      const spyLog = jest
+        .spyOn(Logger.prototype, 'log')
+        .mockImplementation(() => {});
+
+      requestLogger(req, res, next as any);
+
+      expect(req.clientVersion).toBeUndefined();
+      expect(next).toHaveBeenCalled();
+      expect(capturedClientVersion).toBeUndefined();
+      expect(spyLog).toHaveBeenCalledWith(
+        expect.not.stringContaining('clientVersion='),
+      );
+    });
+
+    it('does not break the request when the header value is malformed', () => {
+      const req: any = {
+        method: 'GET',
+        originalUrl: '/test',
+        headers: { 'x-client-version': 'not\na valid version!!' },
+        ip: '1.2.3.4',
+      };
+      const res: any = { setHeader: jest.fn(), on: jest.fn(), statusCode: 200 };
+      const next = jest.fn();
+
+      jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {});
+
+      expect(() => requestLogger(req, res, next as any)).not.toThrow();
+      expect(next).toHaveBeenCalled();
+      expect(req.clientVersion).toBeUndefined();
+    });
   });
 });

--- a/src/common/middleware/request-logging.middleware.ts
+++ b/src/common/middleware/request-logging.middleware.ts
@@ -3,6 +3,39 @@ import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { RequestContextService } from '../request-context/request-context.service';
 
+// Client-reported app version, e.g. "2.4.1" or "ios-2.4.1". Kept
+// intentionally permissive (covers semver plus common platform prefixes)
+// while still rejecting anything long enough or shaped enough to be log
+// injection / control characters rather than a genuine version string.
+const CLIENT_VERSION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/;
+
+/**
+ * Reads and validates the optional `X-Client-Version` header used to tag
+ * support logs with the reporting client's app version. Returns undefined
+ * (never throws) when the header is absent, empty, or doesn't look like a
+ * safe version string — callers should treat a missing client version as a
+ * non-fatal, expected case.
+ */
+export function extractClientVersion(req: Request | any): string | undefined {
+  if (!req || !req.headers) {
+    return undefined;
+  }
+
+  const raw = req.headers['x-client-version'] ?? req.headers['X-Client-Version'];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed || !CLIENT_VERSION_PATTERN.test(trimmed)) {
+    return undefined;
+  }
+
+  return trimmed;
+}
+
 export function requestLogger(
   req: Request | any,
   res: Response | any,
@@ -16,6 +49,8 @@ export function requestLogger(
     return;
   }
 
+  let clientVersion: string | undefined;
+
   try {
     const idHeader =
       req.headers &&
@@ -27,6 +62,12 @@ export function requestLogger(
     const start = Date.now();
 
     req.requestId = id;
+
+    // Optional client app version, e.g. "2.4.1". Never fatal to the request
+    // — a missing or malformed header simply means downstream support logs
+    // won't be tagged with a client version.
+    clientVersion = extractClientVersion(req);
+    req.clientVersion = clientVersion;
 
     if (res && typeof res.setHeader === 'function') {
       try {
@@ -40,14 +81,19 @@ export function requestLogger(
       (req.ip || (req.socket && req.socket.remoteAddress)) || 'unknown';
     const method = req.method || 'UNKNOWN';
     const url = (req.originalUrl || req.url) || 'unknown';
+    const clientVersionSuffix = clientVersion
+      ? ` clientVersion=${clientVersion}`
+      : '';
 
-    logger.log(`${method} ${url} id=${id} ip=${ip}`);
+    logger.log(`${method} ${url} id=${id} ip=${ip}${clientVersionSuffix}`);
 
     if (res && typeof res.on === 'function') {
       res.on('finish', () => {
         const ms = Date.now() - start;
         try {
-          logger.log(`Completed ${res.statusCode || 0} in ${ms}ms id=${id}`);
+          logger.log(
+            `Completed ${res.statusCode || 0} in ${ms}ms id=${id}${clientVersionSuffix}`,
+          );
         } catch (e) {
           logger.warn(
             'Failed to log response finish: ' + (e && (e as Error).message),
@@ -56,7 +102,7 @@ export function requestLogger(
       });
     }
 
-    RequestContextService.run({ requestId: id }, () => {
+    RequestContextService.run({ requestId: id, clientVersion }, () => {
       try {
         next();
       } catch (e) {
@@ -66,12 +112,14 @@ export function requestLogger(
   } catch (err: any) {
     logger.warn('Request logging failed: ' + (err && err.message));
     try {
-      // Propagate the request ID through AsyncLocalStorage so downstream
-      // code (controllers, services — e.g. auth/session flows) can access
-      // it via RequestContextService without needing direct access to the
-      // Express request object.
+      // Propagate the request ID (and client version, when present) through
+      // AsyncLocalStorage so downstream code (controllers, services — e.g.
+      // auth/session flows) can access it via RequestContextService without
+      // needing direct access to the Express request object.
       if (id) {
-        RequestContextService.run({ requestId: id }, () => next());
+        RequestContextService.run({ requestId: id, clientVersion }, () =>
+          next(),
+        );
       } else {
         next();
       }

--- a/src/common/request-context/request-context.service.spec.ts
+++ b/src/common/request-context/request-context.service.spec.ts
@@ -48,4 +48,57 @@ describe('RequestContextService', () => {
       }),
     ]);
   });
+
+  describe('clientVersion', () => {
+    it('should store and retrieve the client version', async () => {
+      await new Promise<void>((resolve) => {
+        RequestContextService.run(
+          { requestId: 'req-1', clientVersion: '2.4.1' },
+          () => {
+            expect(service.getClientVersion()).toBe('2.4.1');
+            resolve();
+          },
+        );
+      });
+    });
+
+    it('should return undefined when no client version is set', async () => {
+      await new Promise<void>((resolve) => {
+        RequestContextService.run({ requestId: 'req-1' }, () => {
+          expect(service.getClientVersion()).toBeUndefined();
+          resolve();
+        });
+      });
+    });
+
+    it('should return undefined outside of any request context', () => {
+      expect(service.getClientVersion()).toBeUndefined();
+      expect(RequestContextService.getCurrentClientVersion()).toBeUndefined();
+    });
+
+    it('setClientVersion updates the client version within the current context', async () => {
+      await new Promise<void>((resolve) => {
+        RequestContextService.run({ requestId: 'req-1' }, () => {
+          service.setClientVersion('1.0.0');
+          expect(service.getClientVersion()).toBe('1.0.0');
+          expect(service.getRequestId()).toBe('req-1');
+          resolve();
+        });
+      });
+    });
+
+    it('static getCurrentClientVersion reads the same store as getClientVersion', async () => {
+      await new Promise<void>((resolve) => {
+        RequestContextService.run(
+          { requestId: 'req-1', clientVersion: '5.6.7' },
+          () => {
+            expect(RequestContextService.getCurrentClientVersion()).toBe(
+              '5.6.7',
+            );
+            resolve();
+          },
+        );
+      });
+    });
+  });
 });

--- a/src/common/request-context/request-context.service.ts
+++ b/src/common/request-context/request-context.service.ts
@@ -3,6 +3,14 @@ import { AsyncLocalStorage } from 'async_hooks';
 
 interface RequestContextData {
   requestId: string;
+  /**
+   * Client application version reported via the `X-Client-Version` request
+   * header (e.g. `2.4.1` or `ios-2.4.1`). Optional — populated only when the
+   * caller sends a well-formed header value. Used to enrich support logs so
+   * wallet/payment/custody issues can be triaged against the reporting
+   * client's version.
+   */
+  clientVersion?: string;
 }
 
 @Injectable()
@@ -19,6 +27,20 @@ export class RequestContextService {
 
   getRequestId(): string | undefined {
     return RequestContextService.asyncLocalStorage.getStore()?.requestId;
+  }
+
+  setClientVersion(clientVersion: string | undefined): void {
+    const current = RequestContextService.asyncLocalStorage.getStore() || {
+      requestId: '',
+    };
+    RequestContextService.asyncLocalStorage.enterWith({
+      ...current,
+      clientVersion,
+    });
+  }
+
+  getClientVersion(): string | undefined {
+    return RequestContextService.asyncLocalStorage.getStore()?.clientVersion;
   }
 
   static bootstrapRequestId(requestId: string): void {
@@ -44,5 +66,14 @@ export class RequestContextService {
    */
   static getCurrentRequestId(): string | undefined {
     return RequestContextService.asyncLocalStorage.getStore()?.requestId;
+  }
+
+  /**
+   * Static convenience accessor mirroring `getCurrentRequestId()`, for
+   * callers that need the reporting client's version (e.g. support-log
+   * enrichment in services) without a DI-injected instance.
+   */
+  static getCurrentClientVersion(): string | undefined {
+    return RequestContextService.asyncLocalStorage.getStore()?.clientVersion;
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ async function bootstrap() {
     },
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-API-Key', 'X-Request-ID'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-API-Key', 'X-Request-ID', 'X-Client-Version'],
     exposedHeaders: ['X-Request-ID', 'X-RateLimit-Remaining', 'X-RateLimit-Reset'],
     maxAge: 3600,
   });

--- a/src/payments/payments-limits.integration.spec.ts
+++ b/src/payments/payments-limits.integration.spec.ts
@@ -36,6 +36,7 @@ describe('Payments and Limits Integration', () => {
 
   const mockRequestContext = {
     getRequestId: jest.fn().mockReturnValue('integration-req-id'),
+    getClientVersion: jest.fn().mockReturnValue(undefined),
   };
 
   beforeEach(async () => {

--- a/src/payments/payments.service.spec.ts
+++ b/src/payments/payments.service.spec.ts
@@ -57,7 +57,10 @@ describe('PaymentsService', () => {
       recordPaymentProcessingDuration: jest.fn(),
       incrementPaymentIdempotencyHit: jest.fn(),
     };
-    requestContext = { getRequestId: jest.fn().mockReturnValue('req-1') };
+    requestContext = {
+      getRequestId: jest.fn().mockReturnValue('req-1'),
+      getClientVersion: jest.fn().mockReturnValue(undefined),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -281,6 +284,58 @@ describe('PaymentsService', () => {
       await service.update('1', { status: PaymentStatus.CONFIRMED });
 
       expect(requestContext.getRequestId).toHaveBeenCalled();
+    });
+  });
+
+  describe('client version propagation (support logs)', () => {
+    it('includes the client version in the update log context when the header was present', async () => {
+      requestContext.getClientVersion.mockReturnValue('2.4.1');
+      prisma.payment.findUnique.mockResolvedValue({
+        id: 1,
+        status: PaymentStatus.PENDING,
+      });
+      prisma.payment.update.mockResolvedValue({
+        id: 1,
+        status: PaymentStatus.CONFIRMED,
+      });
+      const logSpy = jest.spyOn(
+        (service as any).logger,
+        'logWithContext',
+      );
+
+      await service.update('1', { status: PaymentStatus.CONFIRMED });
+
+      expect(requestContext.getClientVersion).toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith(
+        'Updating payment',
+        expect.objectContaining({ clientVersion: '2.4.1' }),
+      );
+    });
+
+    it('omits the client version from the log context without breaking the request when the header was absent', async () => {
+      requestContext.getClientVersion.mockReturnValue(undefined);
+      prisma.payment.findUnique.mockResolvedValue({
+        id: 1,
+        status: PaymentStatus.PENDING,
+      });
+      prisma.payment.update.mockResolvedValue({
+        id: 1,
+        status: PaymentStatus.CONFIRMED,
+      });
+      const logSpy = jest.spyOn(
+        (service as any).logger,
+        'logWithContext',
+      );
+
+      const result = await service.update('1', {
+        status: PaymentStatus.CONFIRMED,
+      });
+
+      expect(result).toBeDefined();
+      expect(logSpy).toHaveBeenCalledWith(
+        'Updating payment',
+        expect.objectContaining({ clientVersion: undefined }),
+      );
     });
   });
 

--- a/src/payments/payments.service.ts
+++ b/src/payments/payments.service.ts
@@ -58,6 +58,7 @@ export class PaymentsService {
 
   async create(createPaymentDto: CreatePaymentDto) {
     const requestId = this.requestContext.getRequestId();
+    const clientVersion = this.requestContext.getClientVersion();
     const start = Date.now();
     const {
       walletId,
@@ -78,6 +79,7 @@ export class PaymentsService {
       if (existing) {
         this.logger.logWithContext('Idempotency hit, returning existing payment', {
           requestId,
+          clientVersion,
           entityId: existing.id.toString(),
           entityType: 'payment',
           operation: 'create',
@@ -220,10 +222,12 @@ export class PaymentsService {
 
   async update(id: string, updatePaymentDto: UpdatePaymentDto) {
     const requestId = this.requestContext.getRequestId();
+    const clientVersion = this.requestContext.getClientVersion();
     const paymentId = parseInt(id, 10);
 
     this.logger.logWithContext('Updating payment', {
       requestId,
+      clientVersion,
       entityId: paymentId.toString(),
       entityType: 'payment',
       operation: 'update',


### PR DESCRIPTION
## Summary
Adds support for an optional `X-Client-Version` request header so support logs can be tagged with the reporting client's app version, making wallet/payment/custody triage easier. The header is read once in the existing request-logging middleware, validated, and threaded through `RequestContextService` — the same mechanism already used for `requestId` — and is now included alongside `requestId` in `PaymentsService`'s structured log lines.

## Context / Before-After
**Before:** Request logs and support logs only carried a `requestId`; there was no way to tell which client app/version produced a given wallet/payment/custody log entry, making cross-referencing frontend/partner bug reports with backend logs harder.

**After:** When a caller sends `X-Client-Version: 2.4.1`, the middleware validates it (trimmed, safe charset, capped length to guard against log injection / oversized values), attaches it to `req.clientVersion`, and propagates it via `RequestContextService` for the lifetime of the request. It now appears in:
- The request-logging middleware's start/completion log lines (`... clientVersion=2.4.1`)
- `PaymentsService` structured logs (`logWithContext`) for `create`/`update`, alongside `requestId`

If the header is absent, empty, or malformed, `clientVersion` is simply omitted (`undefined`) everywhere — the request proceeds normally and nothing breaks. The header is also documented as an optional global header in the generated OpenAPI spec (`scripts/generate-openapi.ts`) and added to the CORS `allowedHeaders` list so browser-based frontend clients can actually send it cross-origin.

## Testing
`pnpm install` was not run in this environment per task constraints (node_modules is intentionally absent), so tests were written and reviewed carefully against existing patterns in the repo but not executed locally. Please run `pnpm test` in CI/locally to verify:
- `src/common/middleware/request-logging.middleware.spec.ts` — header present vs. absent vs. malformed paths
- `src/common/request-context/request-context.service.spec.ts` — `clientVersion` get/set and static accessor
- `src/payments/payments.service.spec.ts` — `clientVersion` threaded into support log context

Closes #562
