### PR TITLE
Resume Horizon history import with cursors

### DIFF
--- a/prisma/migrations/20260729020000_add_horizon_import_cursor/migration.sql
+++ b/prisma/migrations/20260729020000_add_horizon_import_cursor/migration.sql
@@ -1,0 +1,26 @@
+-- CreateEnum
+CREATE TYPE "HorizonImportStatus" AS ENUM ('PENDING', 'RUNNING', 'COMPLETED', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "HorizonImportCursor" (
+    "id" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "network" "WalletNetwork" NOT NULL DEFAULT 'TESTNET',
+    "resourceType" TEXT NOT NULL,
+    "cursor" TEXT,
+    "status" "HorizonImportStatus" NOT NULL DEFAULT 'PENDING',
+    "recordsImported" INTEGER NOT NULL DEFAULT 0,
+    "lastError" TEXT,
+    "lastAttemptAt" TIMESTAMP(3),
+    "lastSuccessAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "HorizonImportCursor_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "HorizonImportCursor_status_idx" ON "HorizonImportCursor"("status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "HorizonImportCursor_accountId_resourceType_network_key" ON "HorizonImportCursor"("accountId", "resourceType", "network");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -984,3 +984,57 @@ model MaintenanceState {
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 }
+
+/// Lifecycle status of a resumable Horizon history import stream.
+enum HorizonImportStatus {
+  PENDING
+  RUNNING
+  COMPLETED
+  FAILED
+}
+
+/// Tracks resumable Horizon history import progress per Stellar account +
+/// history resource (e.g. "payments", "operations"). Persists the last
+/// successfully processed Horizon paging token ("cursor") so a re-run of the
+/// import resumes exactly where it left off instead of re-scanning history
+/// from the beginning after a restart or transient Horizon failure.
+///
+/// The cursor is only advanced on a successful page fetch+persist; a failed
+/// attempt records `status = FAILED` and `lastError` but leaves `cursor`
+/// untouched so the next run retries from the last known-good position.
+model HorizonImportCursor {
+  id     String @id @default(uuid())
+
+  /// Stellar account public key whose history is being imported
+  accountId String
+
+  /// Network scope — the same account may be imported on both networks
+  network WalletNetwork @default(TESTNET)
+
+  /// Horizon history resource being streamed, e.g. "payments", "operations", "transactions"
+  resourceType String
+
+  /// Last successfully processed Horizon paging token. Null = import has not
+  /// made progress yet (starts from the beginning of history on next run).
+  cursor String?
+
+  /// Lifecycle status of the most recent import attempt
+  status HorizonImportStatus @default(PENDING)
+
+  /// Cumulative count of records imported across all resumed runs
+  recordsImported Int @default(0)
+
+  /// Error tracking for the most recent failed attempt.
+  /// Only ever holds a short human-readable message — never response bodies,
+  /// headers, or credentials, so failures can be persisted without risking
+  /// secret leakage into the database or logs.
+  lastError     String?
+  lastAttemptAt DateTime?
+  lastSuccessAt DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([accountId, resourceType, network])
+  @@index([status])
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,6 +23,7 @@ import { KeyManagementModule } from './key-management/key-management.module';
 import { BalanceIndexerModule } from './balance-indexer/balance-indexer.module';
 import { WebhookModule } from './webhooks/webhook.module';
 import { TransactionsModule } from './transactions/transactions.module';
+import { HorizonHistoryImportModule } from './horizon-history-import/horizon-history-import.module';
 import { DevelopersModule } from './developers/developers.module';
 import { ProjectsModule } from './projects/projects.module';
 import { HealthModule } from './health/health.module';
@@ -51,6 +52,7 @@ import { LatencySloInterceptor } from './common/slo/latency-slo.interceptor';
     BalanceIndexerModule,
     WebhookModule,
     TransactionsModule,
+    HorizonHistoryImportModule,
     DevelopersModule,
     ProjectsModule,
     HealthModule,

--- a/src/horizon-history-import/domain/horizon-import.model.ts
+++ b/src/horizon-history-import/domain/horizon-import.model.ts
@@ -1,0 +1,34 @@
+/**
+ * Domain types for resumable Horizon history import.
+ *
+ * Mirrors the `HorizonImportCursor` Prisma model's enum/string fields as
+ * plain TypeScript so application code does not need to import the
+ * generated Prisma client types directly (matching the pattern used by
+ * `BalanceSyncStatus` in `balance-indexer/domain/balance.model.ts`).
+ */
+
+/** Lifecycle status of the most recent import attempt for a cursor. */
+export enum HorizonImportStatus {
+  PENDING = 'PENDING',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+}
+
+/** Horizon history resource streams supported for resumable import. */
+export enum HorizonHistoryResourceType {
+  PAYMENTS = 'payments',
+  OPERATIONS = 'operations',
+  TRANSACTIONS = 'transactions',
+}
+
+export interface HorizonHistoryRecord {
+  paging_token: string;
+  [key: string]: unknown;
+}
+
+export interface HorizonHistoryPage {
+  _embedded?: {
+    records?: HorizonHistoryRecord[];
+  };
+}

--- a/src/horizon-history-import/dto/import-result.response.ts
+++ b/src/horizon-history-import/dto/import-result.response.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { WalletNetwork } from '../../wallets/domain/wallet.model';
+import {
+  HorizonHistoryResourceType,
+  HorizonImportStatus,
+} from '../domain/horizon-import.model';
+
+export class ImportResultResponseDto {
+  @ApiProperty({ example: 'GABC...XYZ', description: 'Stellar account public key' })
+  accountId: string;
+
+  @ApiProperty({ enum: WalletNetwork, example: WalletNetwork.TESTNET })
+  network: WalletNetwork;
+
+  @ApiProperty({
+    enum: HorizonHistoryResourceType,
+    example: HorizonHistoryResourceType.PAYMENTS,
+  })
+  resourceType: HorizonHistoryResourceType;
+
+  @ApiProperty({
+    example: '12345678901234-1',
+    nullable: true,
+    description: 'Horizon paging token the next resume call will start from',
+  })
+  cursor: string | null;
+
+  @ApiProperty({
+    example: 42,
+    description: 'Cumulative records imported across all resumed runs',
+  })
+  recordsImported: number;
+
+  @ApiProperty({
+    example: 20,
+    description: 'Records processed during this call',
+  })
+  recordsImportedThisRun: number;
+
+  @ApiProperty({ enum: HorizonImportStatus, example: HorizonImportStatus.COMPLETED })
+  status: HorizonImportStatus;
+}

--- a/src/horizon-history-import/dto/resume-import.dto.ts
+++ b/src/horizon-history-import/dto/resume-import.dto.ts
@@ -1,0 +1,43 @@
+import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import { WalletNetwork } from '../../wallets/domain/wallet.model';
+import { HorizonHistoryResourceType } from '../domain/horizon-import.model';
+
+export class ResumeImportDto {
+  @ApiProperty({
+    enum: WalletNetwork,
+    required: false,
+    default: WalletNetwork.TESTNET,
+    description: 'Stellar network to import history from',
+  })
+  @IsEnum(WalletNetwork, { message: 'network must be MAINNET or TESTNET' })
+  @IsOptional()
+  network?: WalletNetwork;
+
+  @ApiProperty({
+    enum: HorizonHistoryResourceType,
+    required: false,
+    default: HorizonHistoryResourceType.PAYMENTS,
+    description: 'Horizon history resource stream to import',
+  })
+  @IsEnum(HorizonHistoryResourceType, {
+    message: 'resourceType must be one of: payments, operations, transactions',
+  })
+  @IsOptional()
+  resourceType?: HorizonHistoryResourceType;
+
+  @ApiProperty({
+    required: false,
+    default: 200,
+    minimum: 1,
+    maximum: 200,
+    description: 'Horizon page size for this resume call',
+  })
+  @Type(() => Number)
+  @IsInt({ message: 'pageLimit must be an integer' })
+  @Min(1, { message: 'pageLimit must be at least 1' })
+  @Max(200, { message: 'pageLimit must be at most 200' })
+  @IsOptional()
+  pageLimit?: number;
+}

--- a/src/horizon-history-import/horizon-history-import.controller.ts
+++ b/src/horizon-history-import/horizon-history-import.controller.ts
@@ -1,0 +1,129 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Query,
+  ValidationPipe,
+} from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { HorizonHistoryImportService } from './horizon-history-import.service';
+import { ResumeImportDto } from './dto/resume-import.dto';
+import { ImportResultResponseDto } from './dto/import-result.response';
+
+/**
+ * Horizon History Import Controller
+ *
+ * Base path: `/horizon-import`
+ *
+ * Triggers (and resumes) importing a Stellar account's history
+ * (payments/operations/transactions) from Stellar Horizon. Progress is
+ * persisted as a Horizon paging-token cursor, so calling `resume` again
+ * after a partial run or a failure continues from where the last
+ * successful page left off instead of re-scanning from the beginning.
+ */
+@ApiTags('horizon-import')
+@Controller('horizon-import')
+export class HorizonHistoryImportController {
+  constructor(
+    private readonly historyImportService: HorizonHistoryImportService,
+  ) {}
+
+  /**
+   * `POST /horizon-import/:accountId/resume`
+   *
+   * Fetches the next page of history for `accountId` starting at the
+   * persisted cursor (or from the beginning of history if none exists
+   * yet), then advances the cursor on success.
+   *
+   * Error responses:
+   * - `400` — invalid accountId/request body, or Horizon rejected the request
+   * - `404` — Stellar account not found on Horizon
+   * - `503` — Horizon (or the underlying network) is unavailable
+   */
+  @Post(':accountId/resume')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Resume Horizon history import for an account' })
+  @ApiParam({ name: 'accountId', description: 'Stellar account public key' })
+  @ApiResponse({
+    status: 200,
+    description: 'Import resumed and advanced by one page',
+    type: ImportResultResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - invalid accountId or request body',
+    example: {
+      statusCode: 400,
+      timestamp: '2026-07-29T12:34:56.789Z',
+      path: '/horizon-import/GABC/resume',
+      method: 'POST',
+      message: 'accountId is required',
+      error: 'Bad Request',
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Stellar account not found on Horizon',
+    example: {
+      statusCode: 404,
+      timestamp: '2026-07-29T12:34:56.789Z',
+      path: '/horizon-import/GABC/resume',
+      method: 'POST',
+      message: 'Stellar account not found on Horizon: GABC...XYZ',
+      error: 'Not Found',
+    },
+  })
+  @ApiResponse({
+    status: 503,
+    description: 'Horizon (or the network) is currently unavailable',
+    example: {
+      statusCode: 503,
+      timestamp: '2026-07-29T12:34:56.789Z',
+      path: '/horizon-import/GABC/resume',
+      method: 'POST',
+      message: 'Horizon server error (503)',
+      error: 'Service Unavailable',
+    },
+  })
+  async resumeImport(
+    @Param('accountId') accountId: string,
+    @Body(ValidationPipe) body: ResumeImportDto = new ResumeImportDto(),
+  ): Promise<ImportResultResponseDto> {
+    return this.historyImportService.resumeImport({
+      accountId,
+      network: body.network,
+      resourceType: body.resourceType,
+      pageLimit: body.pageLimit,
+    });
+  }
+
+  /**
+   * `GET /horizon-import/:accountId/cursor`
+   *
+   * Returns the currently persisted cursor state for the account +
+   * resource stream, or `null` if no import has run yet.
+   */
+  @Get(':accountId/cursor')
+  @ApiOperation({ summary: 'Get persisted Horizon import cursor for an account' })
+  @ApiParam({ name: 'accountId', description: 'Stellar account public key' })
+  @ApiResponse({ status: 200, description: 'Cursor state (or null if none exists)' })
+  async getCursor(
+    @Param('accountId') accountId: string,
+    @Query(ValidationPipe) query: ResumeImportDto = new ResumeImportDto(),
+  ) {
+    return this.historyImportService.getCursor(
+      accountId,
+      query.resourceType,
+      query.network,
+    );
+  }
+}

--- a/src/horizon-history-import/horizon-history-import.module.ts
+++ b/src/horizon-history-import/horizon-history-import.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { HorizonHistoryImportService } from './horizon-history-import.service';
+import { HorizonHistoryImportController } from './horizon-history-import.controller';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [HorizonHistoryImportController],
+  providers: [HorizonHistoryImportService],
+  exports: [HorizonHistoryImportService],
+})
+export class HorizonHistoryImportModule {}

--- a/src/horizon-history-import/horizon-history-import.service.spec.ts
+++ b/src/horizon-history-import/horizon-history-import.service.spec.ts
@@ -1,0 +1,286 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  NotFoundException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import { HorizonHistoryImportService } from './horizon-history-import.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { WalletNetwork } from '../wallets/domain/wallet.model';
+import {
+  HorizonHistoryResourceType,
+  HorizonImportStatus,
+} from './domain/horizon-import.model';
+
+jest.mock('axios');
+
+describe('HorizonHistoryImportService', () => {
+  let service: HorizonHistoryImportService;
+  let mockAxiosInstance: {
+    get: jest.Mock;
+    interceptors: { request: { use: jest.Mock } };
+  };
+  let horizonImportCursor: {
+    upsert: jest.Mock;
+    update: jest.Mock;
+    findUnique: jest.Mock;
+  };
+
+  const ACCOUNT_ID = 'GABC123456789';
+  const CURSOR_ID = 'cursor-uuid-1';
+
+  function makeCursorRecord(overrides: Partial<any> = {}) {
+    return {
+      id: CURSOR_ID,
+      accountId: ACCOUNT_ID,
+      network: WalletNetwork.TESTNET,
+      resourceType: HorizonHistoryResourceType.PAYMENTS,
+      cursor: null,
+      status: HorizonImportStatus.RUNNING,
+      recordsImported: 0,
+      lastError: null,
+      lastAttemptAt: new Date(),
+      lastSuccessAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    mockAxiosInstance = {
+      get: jest.fn(),
+      interceptors: { request: { use: jest.fn() } },
+    };
+    (axios.create as jest.Mock).mockReturnValue(mockAxiosInstance);
+
+    horizonImportCursor = {
+      upsert: jest.fn(),
+      update: jest.fn(),
+      findUnique: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HorizonHistoryImportService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((_key: string, defaultValue?: unknown) => defaultValue),
+          },
+        },
+        {
+          provide: PrismaService,
+          useValue: { horizonImportCursor },
+        },
+      ],
+    }).compile();
+
+    service = module.get(HorizonHistoryImportService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('resumeImport - success path', () => {
+    it('starts from the beginning when no cursor is persisted yet', async () => {
+      horizonImportCursor.upsert.mockResolvedValue(makeCursorRecord());
+      mockAxiosInstance.get.mockResolvedValue({
+        data: {
+          _embedded: {
+            records: [
+              { paging_token: '100', id: 'op-1' },
+              { paging_token: '200', id: 'op-2' },
+            ],
+          },
+        },
+      });
+      horizonImportCursor.update.mockResolvedValue(
+        makeCursorRecord({
+          cursor: '200',
+          status: HorizonImportStatus.COMPLETED,
+          recordsImported: 2,
+        }),
+      );
+
+      const result = await service.resumeImport({ accountId: ACCOUNT_ID });
+
+      // First page fetch must not send a `cursor` param when none is persisted
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+        expect.stringContaining(`/accounts/${ACCOUNT_ID}/payments`),
+        expect.objectContaining({
+          params: expect.not.objectContaining({ cursor: expect.anything() }),
+        }),
+      );
+
+      expect(result).toEqual({
+        accountId: ACCOUNT_ID,
+        network: WalletNetwork.TESTNET,
+        resourceType: HorizonHistoryResourceType.PAYMENTS,
+        cursor: '200',
+        recordsImported: 2,
+        recordsImportedThisRun: 2,
+        status: HorizonImportStatus.COMPLETED,
+      });
+
+      expect(horizonImportCursor.update).toHaveBeenCalledWith({
+        where: { id: CURSOR_ID },
+        data: {
+          cursor: '200',
+          status: HorizonImportStatus.COMPLETED,
+          recordsImported: { increment: 2 },
+          lastSuccessAt: expect.any(Date),
+          lastError: null,
+        },
+      });
+    });
+
+    it('resumes from the persisted cursor and advances it further', async () => {
+      horizonImportCursor.upsert.mockResolvedValue(
+        makeCursorRecord({ cursor: '200', recordsImported: 2 }),
+      );
+      mockAxiosInstance.get.mockResolvedValue({
+        data: {
+          _embedded: {
+            records: [{ paging_token: '300', id: 'op-3' }],
+          },
+        },
+      });
+      horizonImportCursor.update.mockResolvedValue(
+        makeCursorRecord({
+          cursor: '300',
+          status: HorizonImportStatus.COMPLETED,
+          recordsImported: 3,
+        }),
+      );
+
+      const result = await service.resumeImport({
+        accountId: ACCOUNT_ID,
+        resourceType: HorizonHistoryResourceType.PAYMENTS,
+      });
+
+      // Resume call must include the previously persisted cursor as a param
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+        expect.stringContaining(`/accounts/${ACCOUNT_ID}/payments`),
+        expect.objectContaining({
+          params: expect.objectContaining({ cursor: '200' }),
+        }),
+      );
+
+      expect(result.cursor).toBe('300');
+      expect(result.recordsImported).toBe(3);
+      expect(result.recordsImportedThisRun).toBe(1);
+    });
+
+    it('keeps the existing cursor unchanged when Horizon returns an empty page', async () => {
+      horizonImportCursor.upsert.mockResolvedValue(
+        makeCursorRecord({ cursor: '200', recordsImported: 2 }),
+      );
+      mockAxiosInstance.get.mockResolvedValue({
+        data: { _embedded: { records: [] } },
+      });
+      horizonImportCursor.update.mockResolvedValue(
+        makeCursorRecord({
+          cursor: '200',
+          status: HorizonImportStatus.COMPLETED,
+          recordsImported: 2,
+        }),
+      );
+
+      const result = await service.resumeImport({ accountId: ACCOUNT_ID });
+
+      expect(result.cursor).toBe('200');
+      expect(result.recordsImportedThisRun).toBe(0);
+      expect(horizonImportCursor.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ cursor: '200' }),
+        }),
+      );
+    });
+  });
+
+  describe('resumeImport - failure paths', () => {
+    it('throws BadRequestException when accountId is missing', async () => {
+      await expect(
+        service.resumeImport({ accountId: '   ' }),
+      ).rejects.toThrow(BadRequestException);
+      expect(horizonImportCursor.upsert).not.toHaveBeenCalled();
+    });
+
+    it('records a FAILED attempt without advancing the cursor on a Horizon network error', async () => {
+      horizonImportCursor.upsert.mockResolvedValue(
+        makeCursorRecord({ cursor: '200', recordsImported: 2 }),
+      );
+      const networkError: any = new Error('ECONNREFUSED');
+      networkError.isAxiosError = true;
+      networkError.response = undefined;
+      mockAxiosInstance.get.mockRejectedValue(networkError);
+      horizonImportCursor.update.mockResolvedValue({});
+
+      await expect(
+        service.resumeImport({ accountId: ACCOUNT_ID }),
+      ).rejects.toThrow(ServiceUnavailableException);
+
+      expect(horizonImportCursor.update).toHaveBeenCalledWith({
+        where: { id: CURSOR_ID },
+        data: {
+          status: HorizonImportStatus.FAILED,
+          lastError: expect.stringContaining('Horizon network error'),
+          lastAttemptAt: expect.any(Date),
+        },
+      });
+      // The failure update must never include a `cursor` key, i.e. the
+      // persisted cursor is left exactly where it was.
+      const failureUpdateArgs = horizonImportCursor.update.mock.calls[0][0];
+      expect(failureUpdateArgs.data).not.toHaveProperty('cursor');
+    });
+
+    it('throws NotFoundException on a Horizon 404 (unknown account)', async () => {
+      horizonImportCursor.upsert.mockResolvedValue(makeCursorRecord());
+      const notFoundError: any = new Error('Not Found');
+      notFoundError.isAxiosError = true;
+      notFoundError.response = { status: 404, data: {} };
+      mockAxiosInstance.get.mockRejectedValue(notFoundError);
+      horizonImportCursor.update.mockResolvedValue({});
+
+      await expect(
+        service.resumeImport({ accountId: ACCOUNT_ID }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ServiceUnavailableException on a Horizon 5xx error', async () => {
+      horizonImportCursor.upsert.mockResolvedValue(makeCursorRecord());
+      const serverError: any = new Error('Internal Server Error');
+      serverError.isAxiosError = true;
+      serverError.response = { status: 503, data: {} };
+      mockAxiosInstance.get.mockRejectedValue(serverError);
+      horizonImportCursor.update.mockResolvedValue({});
+
+      await expect(
+        service.resumeImport({ accountId: ACCOUNT_ID }),
+      ).rejects.toThrow(ServiceUnavailableException);
+    });
+
+    it('never leaks Horizon response bodies/headers into the persisted error message', async () => {
+      horizonImportCursor.upsert.mockResolvedValue(makeCursorRecord());
+      const rejectionError: any = new Error('Bad Request');
+      rejectionError.isAxiosError = true;
+      rejectionError.response = {
+        status: 400,
+        data: { secret_token: 'super-secret-value', detail: 'bad cursor' },
+        headers: { authorization: 'Bearer secret-token' },
+      };
+      mockAxiosInstance.get.mockRejectedValue(rejectionError);
+      horizonImportCursor.update.mockResolvedValue({});
+
+      await expect(
+        service.resumeImport({ accountId: ACCOUNT_ID }),
+      ).rejects.toThrow(BadRequestException);
+
+      const failureUpdateArgs = horizonImportCursor.update.mock.calls[0][0];
+      expect(failureUpdateArgs.data.lastError).not.toContain('secret');
+      expect(failureUpdateArgs.data.lastError).not.toContain('Bearer');
+    });
+  });
+});

--- a/src/horizon-history-import/horizon-history-import.service.ts
+++ b/src/horizon-history-import/horizon-history-import.service.ts
@@ -1,0 +1,318 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AxiosError } from 'axios';
+import { createRequestIdAwareAxios } from '../common/http/request-id-axios';
+import { PrismaService } from '../prisma/prisma.service';
+import { WalletNetwork } from '../wallets/domain/wallet.model';
+import {
+  HorizonHistoryPage,
+  HorizonHistoryResourceType,
+  HorizonImportStatus,
+} from './domain/horizon-import.model';
+
+const DEFAULT_RESOURCE_TYPE = HorizonHistoryResourceType.PAYMENTS;
+const DEFAULT_PAGE_LIMIT = 200;
+
+export interface ResumeHistoryImportRequest {
+  /** Stellar account public key whose history is being imported */
+  accountId: string;
+  network?: WalletNetwork;
+  resourceType?: HorizonHistoryResourceType;
+  /** Horizon page size (1-200, Horizon's own max) */
+  pageLimit?: number;
+}
+
+export interface ResumeHistoryImportResult {
+  accountId: string;
+  network: WalletNetwork;
+  resourceType: HorizonHistoryResourceType;
+  /** Horizon paging token the import will resume from on the next call */
+  cursor: string | null;
+  /** Cumulative records imported across all resumed runs for this stream */
+  recordsImported: number;
+  /** Records processed during this specific call */
+  recordsImportedThisRun: number;
+  status: HorizonImportStatus.COMPLETED;
+}
+
+/**
+ * Resumable Horizon history import.
+ *
+ * Streams a Stellar account's history (payments/operations/transactions)
+ * from Horizon page by page, persisting the last successfully processed
+ * paging token ("cursor") via `HorizonImportCursor`. Re-running the import
+ * for the same account + resourceType + network resumes from the persisted
+ * cursor instead of re-scanning history from the beginning.
+ *
+ * The cursor only advances after a page has been fetched *and* the new
+ * cursor value has been durably persisted. On any failure — Horizon error,
+ * network error, or a persistence error — the previously persisted cursor
+ * is left untouched, so the next attempt safely retries the same page.
+ *
+ * Environment variables:
+ * - `STELLAR_HORIZON_URL`         — fallback Horizon base URL
+ * - `STELLAR_HORIZON_TESTNET_URL` — testnet Horizon base URL (default: horizon-testnet.stellar.org)
+ * - `STELLAR_HORIZON_MAINNET_URL` — mainnet Horizon base URL (default: horizon.stellar.org)
+ */
+@Injectable()
+export class HorizonHistoryImportService {
+  private readonly logger = new Logger(HorizonHistoryImportService.name);
+  private readonly http = createRequestIdAwareAxios();
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  /**
+   * Resumes (or starts) a Horizon history import for a Stellar account.
+   */
+  async resumeImport(
+    request: ResumeHistoryImportRequest,
+  ): Promise<ResumeHistoryImportResult> {
+    const accountId = request.accountId?.trim();
+    if (!accountId) {
+      throw new BadRequestException('accountId is required');
+    }
+
+    const network = request.network ?? WalletNetwork.TESTNET;
+    const resourceType = request.resourceType ?? DEFAULT_RESOURCE_TYPE;
+    const pageLimit = this.normalizePageLimit(request.pageLimit);
+
+    const cursorRecord = await this.prisma.horizonImportCursor.upsert({
+      where: {
+        accountId_resourceType_network: {
+          accountId,
+          resourceType,
+          network,
+        },
+      },
+      create: {
+        accountId,
+        resourceType,
+        network,
+        status: HorizonImportStatus.RUNNING,
+        lastAttemptAt: new Date(),
+      },
+      update: {
+        status: HorizonImportStatus.RUNNING,
+        lastAttemptAt: new Date(),
+      },
+    });
+
+    this.logger.log(
+      `Resuming Horizon ${resourceType} import for account ${this.maskAccountId(accountId)} ` +
+        `(network=${network}, cursor=${cursorRecord.cursor ?? '<start>'})`,
+    );
+
+    let page: HorizonHistoryPage;
+    try {
+      page = await this.fetchPage(
+        accountId,
+        resourceType,
+        network,
+        cursorRecord.cursor ?? null,
+        pageLimit,
+      );
+    } catch (error) {
+      await this.recordFailure(cursorRecord.id, error);
+      throw this.mapHorizonError(error, accountId);
+    }
+
+    const records = page._embedded?.records ?? [];
+    const newCursor =
+      records.length > 0
+        ? records[records.length - 1].paging_token
+        : (cursorRecord.cursor ?? null);
+
+    try {
+      const updated = await this.prisma.horizonImportCursor.update({
+        where: { id: cursorRecord.id },
+        data: {
+          cursor: newCursor,
+          status: HorizonImportStatus.COMPLETED,
+          recordsImported: { increment: records.length },
+          lastSuccessAt: new Date(),
+          lastError: null,
+        },
+      });
+
+      this.logger.log(
+        `Horizon ${resourceType} import resumed for account ${this.maskAccountId(accountId)}: ` +
+          `${records.length} record(s) processed, cursor=${updated.cursor ?? '<start>'}`,
+      );
+
+      return {
+        accountId,
+        network,
+        resourceType,
+        cursor: updated.cursor,
+        recordsImported: updated.recordsImported,
+        recordsImportedThisRun: records.length,
+        status: HorizonImportStatus.COMPLETED,
+      };
+    } catch (error) {
+      // The Horizon fetch already succeeded but persisting the advanced
+      // cursor failed. Best-effort mark the attempt failed (without
+      // touching `cursor`) so the *next* run retries this same page rather
+      // than silently appearing to have made progress.
+      await this.recordFailure(cursorRecord.id, error);
+      this.logger.error(
+        `Failed to persist advanced cursor for account ${this.maskAccountId(accountId)}:`,
+        error,
+      );
+      throw new ServiceUnavailableException(
+        'Failed to persist Horizon import progress. Please retry.',
+      );
+    }
+  }
+
+  /**
+   * Returns the currently persisted cursor state for an account + resource
+   * stream, or `null` if no import has ever been attempted.
+   */
+  async getCursor(
+    accountId: string,
+    resourceType: HorizonHistoryResourceType = DEFAULT_RESOURCE_TYPE,
+    network: WalletNetwork = WalletNetwork.TESTNET,
+  ) {
+    return this.prisma.horizonImportCursor.findUnique({
+      where: {
+        accountId_resourceType_network: {
+          accountId,
+          resourceType,
+          network,
+        },
+      },
+    });
+  }
+
+  private async fetchPage(
+    accountId: string,
+    resourceType: HorizonHistoryResourceType,
+    network: WalletNetwork,
+    cursor: string | null,
+    limit: number,
+  ): Promise<HorizonHistoryPage> {
+    const baseUrl = this.resolveHorizonUrl(network);
+    const response = await this.http.get<HorizonHistoryPage>(
+      `${baseUrl}/accounts/${accountId}/${resourceType}`,
+      {
+        params: {
+          order: 'asc',
+          limit,
+          ...(cursor ? { cursor } : {}),
+        },
+      },
+    );
+    return response.data;
+  }
+
+  private resolveHorizonUrl(network: WalletNetwork): string {
+    if (network === WalletNetwork.MAINNET) {
+      return this.configService.get<string>(
+        'STELLAR_HORIZON_MAINNET_URL',
+        'https://horizon.stellar.org',
+      );
+    }
+    return this.configService.get<string>(
+      'STELLAR_HORIZON_TESTNET_URL',
+      this.configService.get<string>(
+        'STELLAR_HORIZON_URL',
+        'https://horizon-testnet.stellar.org',
+      ),
+    );
+  }
+
+  private normalizePageLimit(pageLimit?: number): number {
+    if (!pageLimit || pageLimit <= 0) return DEFAULT_PAGE_LIMIT;
+    return Math.min(pageLimit, 200);
+  }
+
+  /**
+   * Best-effort persistence of a failed attempt. Never advances `cursor` —
+   * only records status/lastError/lastAttemptAt — so a subsequent call
+   * resumes from the last known-good position.
+   */
+  private async recordFailure(
+    cursorId: string,
+    error: unknown,
+  ): Promise<void> {
+    const message = this.sanitizeErrorMessage(error);
+    try {
+      await this.prisma.horizonImportCursor.update({
+        where: { id: cursorId },
+        data: {
+          status: HorizonImportStatus.FAILED,
+          lastError: message,
+          lastAttemptAt: new Date(),
+        },
+      });
+    } catch (persistError) {
+      this.logger.error(
+        `Failed to persist import failure state for cursor ${cursorId}`,
+        persistError,
+      );
+    }
+  }
+
+  /**
+   * Maps a Horizon/network failure into a consistent Nest HTTP exception.
+   * Only ever surfaces a short status/message summary — never raw response
+   * bodies, headers, or request config, which could otherwise leak
+   * sensitive upstream details into API responses or logs.
+   */
+  private mapHorizonError(error: unknown, accountId: string): Error {
+    const axiosErr = error as AxiosError;
+
+    if (!axiosErr?.isAxiosError) {
+      return error instanceof Error ? error : new Error(String(error));
+    }
+
+    if (!axiosErr.response) {
+      return new ServiceUnavailableException(
+        `Horizon network error: ${axiosErr.message}`,
+      );
+    }
+
+    const status = axiosErr.response.status;
+
+    if (status === 404) {
+      return new NotFoundException(
+        `Stellar account not found on Horizon: ${this.maskAccountId(accountId)}`,
+      );
+    }
+
+    if (status >= 500) {
+      return new ServiceUnavailableException(
+        `Horizon server error (${status})`,
+      );
+    }
+
+    return new BadRequestException(
+      `Horizon rejected the import request (${status})`,
+    );
+  }
+
+  private sanitizeErrorMessage(error: unknown): string {
+    const axiosErr = error as AxiosError;
+    if (axiosErr?.isAxiosError) {
+      const status = axiosErr.response?.status;
+      return status
+        ? `Horizon request failed with status ${status}`
+        : `Horizon network error: ${axiosErr.message}`;
+    }
+    return error instanceof Error ? error.message : 'Unknown import error';
+  }
+
+  private maskAccountId(accountId: string): string {
+    if (accountId.length <= 8) return accountId;
+    return `${accountId.substring(0, 4)}...${accountId.substring(accountId.length - 4)}`;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a new `HorizonHistoryImportModule` that streams a Stellar account's history (payments/operations/transactions) from Horizon and persists the last successfully processed paging token as a durable cursor. Re-running the import for the same account/resourceType/network now resumes from that cursor instead of re-scanning history from the beginning, and failures leave the cursor untouched so retries are safe.

## Context / Before-After
- **Before:** there was no resumable Horizon history import path in the backend — no persisted paging-token cursor existed anywhere in the schema or services, so any history sync would have had to restart from the beginning of an account's history on every run/restart.
- **After:** `POST /horizon-import/:accountId/resume` fetches the next Horizon page starting at the persisted `HorizonImportCursor` row (keyed by `accountId` + `resourceType` + `network`), and only advances the cursor once the new value is durably written. `GET /horizon-import/:accountId/cursor` exposes the current cursor state. On any Horizon/network/persistence failure the cursor is left exactly where it was, the attempt is recorded as `FAILED` with a sanitized (no response bodies/headers/secrets) error message, and the API returns a consistent mapped error (400 invalid request, 404 unknown account, 503 Horizon/network unavailable).

## Testing
`pnpm install` was not run in this environment per task constraints (node_modules is intentionally absent here), so the new unit tests were written and carefully reviewed against the implementation but **not executed locally**. Please run `pnpm test` in CI/locally to verify `src/horizon-history-import/horizon-history-import.service.spec.ts`, which covers:
- Success: starting import with no prior cursor, resuming from a persisted cursor (verifying the `cursor` query param is sent to Horizon), and an empty-page run that leaves the cursor unchanged.
- Failure: missing `accountId` (400), Horizon network error (503, cursor not advanced), Horizon 404 (account not found), Horizon 5xx (503), and a check that persisted error messages never leak upstream response bodies/headers.

Closes #560
