### PR TITLE
feat: webhook subscriptions, signed export links, recovery cancel, IS…

### DIFF
--- a/src/common/interceptors/index.ts
+++ b/src/common/interceptors/index.ts
@@ -1,1 +1,2 @@
 export { ResponseSanitizerInterceptor } from './response-sanitizer.interceptor';
+export { IsoUtcTimestampInterceptor } from './iso-utc-timestamp.interceptor';

--- a/src/common/interceptors/iso-utc-timestamp.interceptor.spec.ts
+++ b/src/common/interceptors/iso-utc-timestamp.interceptor.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for ISO UTC timestamp serialization interceptor (#556).
+ *
+ * Covers:
+ *  - Date objects are converted to ISO strings
+ *  - Nested Date objects inside objects and arrays are converted
+ *  - Null and undefined values pass through untouched
+ *  - Primitive values (string, number, boolean) pass through untouched
+ *  - Strings that look like dates are NOT double-converted
+ *  - Circular-depth protection (capped at depth 20)
+ */
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { of } from 'rxjs';
+import { IsoUtcTimestampInterceptor } from './iso-utc-timestamp.interceptor';
+
+function createMockContext(): ExecutionContext {
+  return {} as ExecutionContext;
+}
+
+function createCallHandler(value: unknown): CallHandler {
+  return {
+    handle: () => of(value),
+  };
+}
+
+function intercept(value: unknown): Promise<unknown> {
+  const interceptor = new IsoUtcTimestampInterceptor();
+  return new Promise((resolve, reject) => {
+    interceptor
+      .intercept(createMockContext(), createCallHandler(value))
+      .subscribe({
+        next: resolve,
+        error: reject,
+      });
+  });
+}
+
+describe('IsoUtcTimestampInterceptor (#556)', () => {
+  const fixedDate = new Date('2026-07-30T02:58:20.651Z');
+  const fixedIso = '2026-07-30T02:58:20.651Z';
+
+  // ── Top-level Date ───────────────────────────────────────────────────────────
+
+  it('converts a top-level Date to an ISO string', async () => {
+    const result = await intercept(fixedDate);
+    expect(result).toBe(fixedIso);
+  });
+
+  // ── Date inside an object ────────────────────────────────────────────────────
+
+  it('converts Date fields inside a plain object', async () => {
+    const result = (await intercept({
+      id: 'abc',
+      createdAt: fixedDate,
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    })) as any;
+
+    expect(result.createdAt).toBe(fixedIso);
+    expect(result.updatedAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(result.id).toBe('abc');
+  });
+
+  // ── Date inside nested objects ───────────────────────────────────────────────
+
+  it('converts Date fields in nested objects', async () => {
+    const result = (await intercept({
+      wallet: {
+        createdAt: fixedDate,
+        nested: {
+          updatedAt: fixedDate,
+        },
+      },
+    })) as any;
+
+    expect(result.wallet.createdAt).toBe(fixedIso);
+    expect(result.wallet.nested.updatedAt).toBe(fixedIso);
+  });
+
+  // ── Date inside an array ─────────────────────────────────────────────────────
+
+  it('converts Date elements inside an array', async () => {
+    const result = (await intercept([
+      { createdAt: fixedDate },
+      { createdAt: new Date('2025-01-01T00:00:00.000Z') },
+    ])) as any[];
+
+    expect(result[0].createdAt).toBe(fixedIso);
+    expect(result[1].createdAt).toBe('2025-01-01T00:00:00.000Z');
+  });
+
+  // ── Null / undefined passthrough ─────────────────────────────────────────────
+
+  it('passes null through unchanged', async () => {
+    const result = await intercept(null);
+    expect(result).toBeNull();
+  });
+
+  it('passes undefined through unchanged', async () => {
+    const result = await intercept(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('passes null field values through unchanged', async () => {
+    const result = (await intercept({ expiresAt: null })) as any;
+    expect(result.expiresAt).toBeNull();
+  });
+
+  // ── Primitives ───────────────────────────────────────────────────────────────
+
+  it('passes string values through unchanged', async () => {
+    const result = await intercept('hello');
+    expect(result).toBe('hello');
+  });
+
+  it('passes number values through unchanged', async () => {
+    const result = await intercept(42);
+    expect(result).toBe(42);
+  });
+
+  it('passes boolean values through unchanged', async () => {
+    expect(await intercept(true)).toBe(true);
+    expect(await intercept(false)).toBe(false);
+  });
+
+  // ── Strings that resemble dates are NOT re-converted ─────────────────────────
+
+  it('does not double-convert a string that already is an ISO date', async () => {
+    const isoString = '2026-07-30T02:58:20.651Z';
+    const result = (await intercept({ ts: isoString })) as any;
+    expect(result.ts).toBe(isoString);
+  });
+
+  // ── Mixed realistic response ──────────────────────────────────────────────────
+
+  it('handles a realistic wallet response shape', async () => {
+    const response = {
+      data: [
+        {
+          id: 'wallet-uuid',
+          publicKey: 'GABC123',
+          status: 'ACTIVE',
+          network: 'TESTNET',
+          createdAt: fixedDate,
+          updatedAt: fixedDate,
+          deletedAt: null,
+        },
+      ],
+      total: 1,
+      limit: 20,
+      offset: 0,
+      hasMore: false,
+    };
+
+    const result = (await intercept(response)) as any;
+
+    expect(result.data[0].createdAt).toBe(fixedIso);
+    expect(result.data[0].updatedAt).toBe(fixedIso);
+    expect(result.data[0].deletedAt).toBeNull();
+    expect(result.total).toBe(1);
+    expect(result.data[0].publicKey).toBe('GABC123');
+  });
+});

--- a/src/common/interceptors/iso-utc-timestamp.interceptor.ts
+++ b/src/common/interceptors/iso-utc-timestamp.interceptor.ts
@@ -1,0 +1,70 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable, map } from 'rxjs';
+
+/**
+ * Recursively walks a plain JS value and converts every `Date` instance to
+ * an ISO 8601 UTC string (e.g. `"2026-07-30T02:58:20.651Z"`).
+ *
+ * This ensures that all timestamps serialized in HTTP responses have a
+ * consistent, timezone-unambiguous format regardless of the locale or
+ * runtime environment of the server.
+ *
+ * Depth is capped at 20 to protect against pathological circular structures
+ * (Prisma models are not circular, but defensive programming is cheap here).
+ */
+function serializeDates(value: unknown, depth = 0): unknown {
+  if (depth > 20 || value === null || value === undefined) return value;
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => serializeDates(item, depth + 1));
+  }
+
+  if (typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      result[key] = serializeDates(val, depth + 1);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+/**
+ * Global interceptor that normalizes all `Date` objects in HTTP response
+ * bodies to ISO 8601 UTC strings.
+ *
+ * Register globally in AppModule:
+ * ```ts
+ * providers: [{ provide: APP_INTERCEPTOR, useClass: IsoUtcTimestampInterceptor }]
+ * ```
+ *
+ * Or at the controller / handler level:
+ * ```ts
+ * \@UseInterceptors(IsoUtcTimestampInterceptor)
+ * ```
+ */
+@Injectable()
+export class IsoUtcTimestampInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    return next.handle().pipe(
+      map((responseBody) => {
+        if (responseBody === null || responseBody === undefined) {
+          return responseBody;
+        }
+        return serializeDates(responseBody);
+      }),
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { AppModule } from './app.module';
 import requestLogger from './common/middleware/request-logging.middleware';
 import { configureBodySizeLimit } from './common/http/body-size-limit';
 import { validateEnv } from './config/env.validation';
+import { IsoUtcTimestampInterceptor } from './common/interceptors';
 
 /**
  * Parses the CORS_ALLOWED_ORIGINS env var into an array of allowed origins.
@@ -61,6 +62,9 @@ async function bootstrap() {
       forbidNonWhitelisted: true,
     }),
   );
+
+  // Normalize all Date values in HTTP responses to ISO 8601 UTC strings.
+  app.useGlobalInterceptors(new IsoUtcTimestampInterceptor());
 
   // Let Nest call onModuleDestroy/beforeApplicationShutdown on SIGTERM/SIGINT
   // so in-flight requests can finish and connections (Prisma, etc.) close cleanly.

--- a/src/recovery/recovery-cancel-553.spec.ts
+++ b/src/recovery/recovery-cancel-553.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for the recovery cancel endpoint (#553).
+ *
+ * Covers:
+ *  - RecoveryService.cancel: PENDING → CANCELLED (success)
+ *  - RecoveryService.cancel: IN_REVIEW → CANCELLED (success)
+ *  - RecoveryService.cancel: APPROVED → CANCELLED (success)
+ *  - RecoveryService.cancel: COMPLETED → error (terminal state)
+ *  - RecoveryService.cancel: REJECTED → error (terminal state)
+ *  - RecoveryService.cancel: CANCELLED → error (already cancelled)
+ *  - RecoveryService.cancel: NotFoundException for unknown ID
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common';
+import { RecoveryService } from './recovery.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { RecoveryStatus } from './domain/recovery.model';
+
+function makeRecovery(status: RecoveryStatus) {
+  return {
+    id: '660e8400-e29b-41d4-a716-446655440001',
+    walletId: '550e8400-e29b-41d4-a716-446655440000',
+    requester: 'user_abc123',
+    status,
+    metadata: null,
+    createdAt: new Date('2026-06-29T12:00:00.000Z'),
+    updatedAt: new Date('2026-06-29T12:00:00.000Z'),
+  };
+}
+
+describe('RecoveryService – cancel endpoint (#553)', () => {
+  let service: RecoveryService;
+  let prisma: any;
+
+  const RECOVERY_ID = '660e8400-e29b-41d4-a716-446655440001';
+
+  beforeEach(async () => {
+    prisma = {
+      recoveryRequest: {
+        findFirst: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        count: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+      wallet: {
+        findUnique: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RecoveryService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<RecoveryService>(RecoveryService);
+  });
+
+  // ── Success paths ────────────────────────────────────────────────────────────
+
+  describe('allowed cancellations', () => {
+    const cancellableStatuses = [
+      RecoveryStatus.PENDING,
+      RecoveryStatus.IN_REVIEW,
+      RecoveryStatus.APPROVED,
+    ];
+
+    for (const status of cancellableStatuses) {
+      it(`cancels a ${status} request`, async () => {
+        const cancelled = { ...makeRecovery(status), status: RecoveryStatus.CANCELLED };
+        prisma.recoveryRequest.findUnique.mockResolvedValue(makeRecovery(status));
+        prisma.recoveryRequest.update.mockResolvedValue(cancelled);
+
+        const result = await service.cancel(RECOVERY_ID);
+
+        expect(result.status).toBe(RecoveryStatus.CANCELLED);
+        expect(prisma.recoveryRequest.update).toHaveBeenCalledWith({
+          where: { id: RECOVERY_ID },
+          data: { status: RecoveryStatus.CANCELLED },
+        });
+      });
+    }
+  });
+
+  // ── Failure paths ────────────────────────────────────────────────────────────
+
+  describe('disallowed cancellations', () => {
+    const terminalStatuses = [
+      RecoveryStatus.COMPLETED,
+      RecoveryStatus.REJECTED,
+      RecoveryStatus.CANCELLED,
+    ];
+
+    for (const status of terminalStatuses) {
+      it(`throws BadRequestException when status is ${status}`, async () => {
+        prisma.recoveryRequest.findUnique.mockResolvedValue(makeRecovery(status));
+
+        await expect(service.cancel(RECOVERY_ID)).rejects.toThrow(
+          BadRequestException,
+        );
+
+        expect(prisma.recoveryRequest.update).not.toHaveBeenCalled();
+      });
+    }
+
+    it('throws NotFoundException when the recovery request does not exist', async () => {
+      prisma.recoveryRequest.findUnique.mockResolvedValue(null);
+
+      await expect(service.cancel('nonexistent-id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ── Error message quality ────────────────────────────────────────────────────
+
+  it('error message mentions the current status when cancellation is disallowed', async () => {
+    prisma.recoveryRequest.findUnique.mockResolvedValue(
+      makeRecovery(RecoveryStatus.COMPLETED),
+    );
+
+    try {
+      await service.cancel(RECOVERY_ID);
+      fail('Expected BadRequestException');
+    } catch (err: any) {
+      expect(err.message).toContain('COMPLETED');
+    }
+  });
+});

--- a/src/recovery/recovery.controller.ts
+++ b/src/recovery/recovery.controller.ts
@@ -9,6 +9,8 @@ import {
   Query,
   BadRequestException,
   ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -419,6 +421,62 @@ export class RecoveryController {
   @Post(':id/initiate')
   initiate(@Param('id', ParseUUIDPipe) id: string) {
     return this.recoveryService.initiate(id);
+  }
+
+  @ApiOperation({
+    summary: 'Cancel a recovery request',
+    description:
+      'Cancels a recovery request by moving it to CANCELLED status. ' +
+      'Only requests in PENDING, IN_REVIEW, or APPROVED state can be cancelled. ' +
+      'Requests that are already COMPLETED, REJECTED, or CANCELLED cannot be cancelled.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Recovery request UUID',
+    example: '660e8400-e29b-41d4-a716-446655440001',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Recovery request cancelled',
+    schema: {
+      example: {
+        id: '660e8400-e29b-41d4-a716-446655440001',
+        walletId: '550e8400-e29b-41d4-a716-446655440000',
+        requester: 'user_abc123',
+        status: 'CANCELLED',
+        metadata: { reason: 'lost_access' },
+        createdAt: '2026-06-29T12:00:00.000Z',
+        updatedAt: '2026-06-29T12:30:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - invalid UUID or cancellation not allowed from current status',
+    schema: {
+      example: {
+        statusCode: 400,
+        message:
+          'Recovery request cannot be cancelled from status COMPLETED. ' +
+          'Only PENDING, IN_REVIEW, or APPROVED requests can be cancelled.',
+        error: 'Bad Request',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Recovery request not found',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: 'Recovery request not found',
+        error: 'Not Found',
+      },
+    },
+  })
+  @Post(':id/cancel')
+  cancel(@Param('id', ParseUUIDPipe) id: string) {
+    return this.recoveryService.cancel(id);
   }
 
   @ApiOperation({

--- a/src/recovery/recovery.service.ts
+++ b/src/recovery/recovery.service.ts
@@ -11,6 +11,7 @@ import { PaginatedRecoveryDto } from './dto/paginated-recovery.dto';
 import {
   RecoveryStatus,
   transitionRecoveryStatus,
+  canTransitionRecoveryStatus,
 } from './domain/recovery.model';
 
 @Injectable()
@@ -163,6 +164,33 @@ export class RecoveryService {
     const result = await this.prisma.recoveryRequest.update({
       where: { id },
       data: { status: transitioned.status },
+    });
+
+    return this.mapPrismaToEntity(result);
+  }
+
+  /**
+   * Cancels a recovery request by transitioning it to CANCELLED status.
+   * Only requests in PENDING, IN_REVIEW, or APPROVED state can be cancelled.
+   *
+   * @param id  Recovery request UUID
+   * @returns   Updated recovery request with status CANCELLED
+   * @throws    NotFoundException   if the request does not exist
+   * @throws    BadRequestException if the transition is not allowed
+   */
+  async cancel(id: string): Promise<RecoveryRequest> {
+    const recovery = await this.findOne(id);
+
+    if (!canTransitionRecoveryStatus(recovery.status, RecoveryStatus.CANCELLED)) {
+      throw new BadRequestException(
+        `Recovery request cannot be cancelled from status ${recovery.status}. ` +
+          `Only PENDING, IN_REVIEW, or APPROVED requests can be cancelled.`,
+      );
+    }
+
+    const result = await this.prisma.recoveryRequest.update({
+      where: { id },
+      data: { status: RecoveryStatus.CANCELLED },
     });
 
     return this.mapPrismaToEntity(result);

--- a/src/transactions/transaction-export-download-552.spec.ts
+++ b/src/transactions/transaction-export-download-552.spec.ts
@@ -1,0 +1,267 @@
+/**
+ * Unit tests for short-lived signed export download links (#552).
+ *
+ * Covers:
+ *  - generateDownloadToken: produces a verifiable token
+ *  - verifyDownloadToken: accepts a valid token
+ *  - verifyDownloadToken: rejects a tampered token
+ *  - verifyDownloadToken: rejects an expired token
+ *  - verifyDownloadToken: rejects a malformed token
+ *  - TransactionExportService.issueDownloadLink: success path
+ *  - TransactionExportService.issueDownloadLink: rejects non-COMPLETED job
+ *  - TransactionExportService.resolveDownload: returns correct content
+ *  - TransactionExportService.resolveDownload: rejects mismatched jobId in token
+ */
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  TransactionExportService,
+  generateDownloadToken,
+  verifyDownloadToken,
+} from './transaction-export.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+// ── Token helpers ─────────────────────────────────────────────────────────────
+
+describe('generateDownloadToken / verifyDownloadToken (#552)', () => {
+  const JOB_ID = 'job-uuid-1';
+  const PROJECT_ID = 'proj-uuid-1';
+
+  it('generates a token that round-trips through verify', () => {
+    const { token } = generateDownloadToken(JOB_ID, PROJECT_ID);
+    const payload = verifyDownloadToken(token);
+
+    expect(payload.jobId).toBe(JOB_ID);
+    expect(payload.projectId).toBe(PROJECT_ID);
+    expect(new Date(payload.expiresAt).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('generated token expires in approximately the specified TTL', () => {
+    const ttlMs = 10 * 60 * 1000; // 10 minutes
+    const before = Date.now();
+    const { expiresAt } = generateDownloadToken(JOB_ID, PROJECT_ID, ttlMs);
+    const after = Date.now();
+
+    // expiresAt should be within [before + ttlMs, after + ttlMs]
+    expect(expiresAt.getTime()).toBeGreaterThanOrEqual(before + ttlMs);
+    expect(expiresAt.getTime()).toBeLessThanOrEqual(after + ttlMs + 100);
+  });
+
+  it('caps TTL to the minimum when a smaller value is supplied', () => {
+    const { expiresAt } = generateDownloadToken(JOB_ID, PROJECT_ID, 1000); // 1 s
+    // Should be capped to 5 min (300 000 ms)
+    const diffMs = expiresAt.getTime() - Date.now();
+    expect(diffMs).toBeGreaterThanOrEqual(4 * 60 * 1000);
+  });
+
+  it('caps TTL to the maximum when a larger value is supplied', () => {
+    const { expiresAt } = generateDownloadToken(
+      JOB_ID,
+      PROJECT_ID,
+      100 * 60 * 60 * 1000, // 100 hours
+    );
+    // Should be capped to 24 h (86 400 000 ms)
+    const diffMs = expiresAt.getTime() - Date.now();
+    expect(diffMs).toBeLessThanOrEqual(24 * 60 * 60 * 1000 + 500);
+  });
+
+  it('rejects a tampered payload', () => {
+    const { token } = generateDownloadToken(JOB_ID, PROJECT_ID);
+    const [, sig] = token.split('.');
+    const fakePaylod = Buffer.from(
+      JSON.stringify({ jobId: 'evil', projectId: PROJECT_ID, expiresAt: new Date(Date.now() + 3600_000).toISOString() }),
+    ).toString('base64url');
+    const tamperedToken = `${fakePaylod}.${sig}`;
+
+    expect(() => verifyDownloadToken(tamperedToken)).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('rejects an expired token', () => {
+    // Build a token whose expiresAt is in the past
+    const past = new Date(Date.now() - 1000).toISOString();
+    const payloadB64 = Buffer.from(
+      JSON.stringify({ jobId: JOB_ID, projectId: PROJECT_ID, expiresAt: past }),
+    ).toString('base64url');
+
+    // Sign it properly so signature is valid, expiry is the issue
+    const crypto = require('crypto');
+    const secret =
+      process.env.EXPORT_SIGNING_SECRET ||
+      'mux-export-signing-secret-change-in-production';
+    const sig = crypto
+      .createHmac('sha256', secret)
+      .update(payloadB64)
+      .digest('base64url');
+    const expiredToken = `${payloadB64}.${sig}`;
+
+    expect(() => verifyDownloadToken(expiredToken)).toThrow(BadRequestException);
+    expect(() => verifyDownloadToken(expiredToken)).toThrow('expired');
+  });
+
+  it('rejects a token with wrong number of segments', () => {
+    expect(() => verifyDownloadToken('no-dot-token')).toThrow(BadRequestException);
+    expect(() => verifyDownloadToken('a.b.c')).toThrow(BadRequestException);
+  });
+
+  it('rejects a token with a non-JSON payload', () => {
+    const crypto = require('crypto');
+    const secret =
+      process.env.EXPORT_SIGNING_SECRET ||
+      'mux-export-signing-secret-change-in-production';
+    const badPayload = Buffer.from('not-json').toString('base64url');
+    const sig = crypto
+      .createHmac('sha256', secret)
+      .update(badPayload)
+      .digest('base64url');
+
+    expect(() => verifyDownloadToken(`${badPayload}.${sig}`)).toThrow(BadRequestException);
+  });
+});
+
+// ── TransactionExportService integration ─────────────────────────────────────
+
+const CSV_DATA = 'id,amount\ntx-1,10.5';
+const DATA_URI = `data:text/csv;base64,${Buffer.from(CSV_DATA).toString('base64')}`;
+
+const completedJob = {
+  id: 'job-1',
+  projectId: 'proj-1',
+  requestedBy: null,
+  format: 'CSV',
+  filters: null,
+  status: 'COMPLETED',
+  rowCount: 1,
+  downloadUrl: DATA_URI,
+  expiresAt: new Date(Date.now() + 3600_000),
+  errorMessage: null,
+  startedAt: new Date('2026-07-30T00:00:00.000Z'),
+  completedAt: new Date('2026-07-30T00:00:01.000Z'),
+  createdAt: new Date('2026-07-30T00:00:00.000Z'),
+  updatedAt: new Date('2026-07-30T00:00:01.000Z'),
+};
+
+const pendingJob = { ...completedJob, status: 'PENDING', downloadUrl: null };
+
+describe('TransactionExportService – download links (#552)', () => {
+  let service: TransactionExportService;
+  let mockPrisma: any;
+
+  beforeEach(async () => {
+    mockPrisma = {
+      transactionExportJob: {
+        create: jest.fn(),
+        update: jest.fn(),
+        findFirst: jest.fn(),
+        findMany: jest.fn(),
+        count: jest.fn(),
+      },
+      transaction: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TransactionExportService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<TransactionExportService>(TransactionExportService);
+  });
+
+  describe('issueDownloadLink', () => {
+    it('returns a token and downloadUrl for a completed job', async () => {
+      mockPrisma.transactionExportJob.findFirst.mockResolvedValue(completedJob);
+
+      const result = await service.issueDownloadLink('job-1', 'proj-1');
+
+      expect(result.token).toBeTruthy();
+      expect(result.expiresAt).toBeInstanceOf(Date);
+      expect(result.downloadUrl).toContain('job-1');
+      expect(result.downloadUrl).toContain('token=');
+    });
+
+    it('throws BadRequestException for a non-COMPLETED job', async () => {
+      mockPrisma.transactionExportJob.findFirst.mockResolvedValue(pendingJob);
+
+      await expect(
+        service.issueDownloadLink('job-1', 'proj-1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFoundException when the job does not exist', async () => {
+      mockPrisma.transactionExportJob.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.issueDownloadLink('nonexistent', 'proj-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('issued token is verifiable and carries correct job/project IDs', async () => {
+      mockPrisma.transactionExportJob.findFirst.mockResolvedValue(completedJob);
+
+      const { token } = await service.issueDownloadLink('job-1', 'proj-1');
+      const payload = verifyDownloadToken(token);
+
+      expect(payload.jobId).toBe('job-1');
+      expect(payload.projectId).toBe('proj-1');
+    });
+  });
+
+  describe('resolveDownload', () => {
+    it('returns the CSV content for a valid token', async () => {
+      const { token } = generateDownloadToken('job-1', 'proj-1');
+      mockPrisma.transactionExportJob.findFirst.mockResolvedValue(completedJob);
+
+      const result = await service.resolveDownload('job-1', token);
+
+      expect(result.mimeType).toBe('text/csv');
+      expect(result.filename).toMatch(/export-job-1\.csv/);
+      expect(result.content.toString('utf8')).toBe(CSV_DATA);
+    });
+
+    it('throws BadRequestException when token jobId does not match route param', async () => {
+      const { token } = generateDownloadToken('job-1', 'proj-1');
+
+      await expect(
+        service.resolveDownload('different-job-id', token),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFoundException when job does not exist for the project in token', async () => {
+      const { token } = generateDownloadToken('job-1', 'proj-1');
+      mockPrisma.transactionExportJob.findFirst.mockResolvedValue(null);
+
+      await expect(service.resolveDownload('job-1', token)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws BadRequestException for a tampered token', async () => {
+      const { token } = generateDownloadToken('job-1', 'proj-1');
+      const tampered = token.slice(0, -5) + 'XXXXX';
+
+      await expect(service.resolveDownload('job-1', tampered)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('correctly resolves a JSON format export', async () => {
+      const jsonData = JSON.stringify([{ id: 'tx-1' }], null, 2);
+      const jsonUri = `data:application/json;base64,${Buffer.from(jsonData).toString('base64')}`;
+      const jsonJob = { ...completedJob, format: 'JSON', downloadUrl: jsonUri };
+
+      const { token } = generateDownloadToken('job-1', 'proj-1');
+      mockPrisma.transactionExportJob.findFirst.mockResolvedValue(jsonJob);
+
+      const result = await service.resolveDownload('job-1', token);
+
+      expect(result.mimeType).toBe('application/json');
+      expect(result.filename).toMatch(/\.json$/);
+      expect(result.content.toString('utf8')).toBe(jsonData);
+    });
+  });
+});

--- a/src/transactions/transaction-export.controller.ts
+++ b/src/transactions/transaction-export.controller.ts
@@ -9,7 +9,9 @@ import {
   HttpStatus,
   UseGuards,
   BadRequestException,
+  Res,
 } from '@nestjs/common';
+import { Response } from 'express';
 import {
   ApiTags,
   ApiOperation,
@@ -175,6 +177,108 @@ export class TransactionExportController {
       })),
       total: result.total,
     };
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /transactions/export/:jobId/issue-link — issue short-lived signed token
+  // ---------------------------------------------------------------------------
+
+  @ApiOperation({
+    summary: 'Issue a short-lived signed download link for a completed export job',
+    description:
+      'Generates a signed token that is valid for 1 hour (configurable via `ttlSeconds`, ' +
+      'min 5 min, max 24 h). ' +
+      'Use the returned `downloadUrl` to fetch the export data. ' +
+      'The token can be re-issued any number of times while the job data exists.',
+  })
+  @ApiParam({ name: 'jobId', description: 'Export job ID' })
+  @ApiQuery({
+    name: 'ttlSeconds',
+    required: false,
+    example: 3600,
+    description: 'Token validity in seconds (default 3600, min 300, max 86400)',
+  })
+  @ApiResponse({
+    status: 200,
+    schema: {
+      example: {
+        jobId: 'uuid',
+        token: 'eyJqb2JJZCI6InV1aWQiLCJwcm9qZWN0SWQiOiJwcm9qLXV1aWQifQ.sig',
+        expiresAt: '2026-07-30T03:58:20.651Z',
+        downloadUrl: '/v1/transactions/export/uuid/download?token=...',
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: 'Job is not completed or data is unavailable' })
+  @ApiResponse({ status: 404, description: 'Export job not found' })
+  @Post(':jobId/issue-link')
+  @HttpCode(HttpStatus.OK)
+  async issueDownloadLink(
+    @Param('jobId') jobId: string,
+    @ApiKeyCtx() ctx: ApiKeyContext,
+    @Query('ttlSeconds') ttlSeconds?: string,
+  ) {
+    const ttlMs = ttlSeconds
+      ? Math.round(parseFloat(ttlSeconds) * 1000)
+      : undefined;
+
+    if (ttlSeconds !== undefined && (isNaN(ttlMs!) || ttlMs! <= 0)) {
+      throw new BadRequestException('ttlSeconds must be a positive number');
+    }
+
+    const result = await this.exportService.issueDownloadLink(
+      jobId,
+      ctx.project.id,
+      ttlMs,
+    );
+
+    return {
+      jobId,
+      token: result.token,
+      expiresAt: result.expiresAt,
+      downloadUrl: result.downloadUrl,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /transactions/export/:jobId/download — download via signed token
+  // ---------------------------------------------------------------------------
+
+  @ApiOperation({
+    summary: 'Download export data using a signed token',
+    description:
+      'Verifies the signed token and streams the export file. ' +
+      'Does **not** require API key authentication — the token is the credential. ' +
+      'Returns the file as an attachment with the appropriate Content-Type header.',
+  })
+  @ApiParam({ name: 'jobId', description: 'Export job ID' })
+  @ApiQuery({
+    name: 'token',
+    required: true,
+    description: 'Signed download token from POST /transactions/export/:jobId/issue-link',
+  })
+  @ApiResponse({ status: 200, description: 'Export file streamed as an attachment' })
+  @ApiResponse({ status: 400, description: 'Token invalid, expired, or job unavailable' })
+  @ApiResponse({ status: 404, description: 'Export job not found' })
+  @Get(':jobId/download')
+  @UseGuards() // Override class-level guards — token IS the auth credential
+  async downloadExport(
+    @Param('jobId') jobId: string,
+    @Query('token') token: string,
+    @Res() res: Response,
+  ) {
+    if (!token) {
+      throw new BadRequestException('token query parameter is required');
+    }
+
+    const { content, mimeType, filename } =
+      await this.exportService.resolveDownload(jobId, token);
+
+    res.setHeader('Content-Type', mimeType);
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.setHeader('Content-Length', content.length);
+    res.setHeader('Cache-Control', 'private, no-store');
+    res.end(content);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/transactions/transaction-export.service.ts
+++ b/src/transactions/transaction-export.service.ts
@@ -5,6 +5,7 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import * as crypto from 'crypto';
 
 export type ExportFormat = 'CSV' | 'JSON';
 
@@ -46,8 +47,105 @@ export interface ExportJobSummary {
   createdAt: Date;
 }
 
-/** How long a completed export download link remains valid (default 24h) */
-const DOWNLOAD_LINK_TTL_MS = 24 * 60 * 60 * 1000;
+/**
+ * Minimum download link TTL: 5 minutes.
+ * Maximum: 24 hours.
+ * Default: 1 hour.
+ */
+const DEFAULT_DOWNLOAD_LINK_TTL_MS = 60 * 60 * 1000; // 1 hour
+const MIN_DOWNLOAD_LINK_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_DOWNLOAD_LINK_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/**
+ * Signing secret for the download token.
+ * In production this should come from an environment variable (EXPORT_SIGNING_SECRET).
+ * We fall back to a deterministic but unguessable derived key in development.
+ */
+function getSigningSecret(): string {
+  return (
+    process.env.EXPORT_SIGNING_SECRET ||
+    'mux-export-signing-secret-change-in-production'
+  );
+}
+
+/**
+ * Generates a short-lived signed download token for a completed export job.
+ *
+ * Token format (URL-safe base64): <payload>.<signature>
+ *   payload = base64url({ jobId, projectId, expiresAt })
+ *   signature = HMAC-SHA256(payload, secret)
+ */
+export function generateDownloadToken(
+  jobId: string,
+  projectId: string,
+  ttlMs: number = DEFAULT_DOWNLOAD_LINK_TTL_MS,
+): { token: string; expiresAt: Date } {
+  const effectiveTtl = Math.min(
+    MAX_DOWNLOAD_LINK_TTL_MS,
+    Math.max(MIN_DOWNLOAD_LINK_TTL_MS, ttlMs),
+  );
+  const expiresAt = new Date(Date.now() + effectiveTtl);
+
+  const payloadObj = { jobId, projectId, expiresAt: expiresAt.toISOString() };
+  const payloadB64 = Buffer.from(JSON.stringify(payloadObj)).toString(
+    'base64url',
+  );
+
+  const sig = crypto
+    .createHmac('sha256', getSigningSecret())
+    .update(payloadB64)
+    .digest('base64url');
+
+  return { token: `${payloadB64}.${sig}`, expiresAt };
+}
+
+export interface DownloadTokenPayload {
+  jobId: string;
+  projectId: string;
+  expiresAt: string;
+}
+
+/**
+ * Verifies and decodes a signed download token.
+ * Throws if the token is malformed, tampered, or expired.
+ */
+export function verifyDownloadToken(token: string): DownloadTokenPayload {
+  const parts = token.split('.');
+  if (parts.length !== 2) {
+    throw new BadRequestException('Invalid download token format');
+  }
+
+  const [payloadB64, sig] = parts;
+
+  const expectedSig = crypto
+    .createHmac('sha256', getSigningSecret())
+    .update(payloadB64)
+    .digest('base64url');
+
+  if (
+    !crypto.timingSafeEqual(
+      Buffer.from(sig, 'base64url'),
+      Buffer.from(expectedSig, 'base64url'),
+    )
+  ) {
+    throw new BadRequestException('Invalid download token signature');
+  }
+
+  let payload: DownloadTokenPayload;
+  try {
+    payload = JSON.parse(
+      Buffer.from(payloadB64, 'base64url').toString('utf8'),
+    );
+  } catch {
+    throw new BadRequestException('Malformed download token payload');
+  }
+
+  if (new Date(payload.expiresAt) < new Date()) {
+    throw new BadRequestException('Download token has expired');
+  }
+
+  return payload;
+}
 
 /**
  * TransactionExportService
@@ -59,10 +157,14 @@ const DOWNLOAD_LINK_TTL_MS = 24 * 60 * 60 * 1000;
  *     export in the background (non-blocking to the HTTP caller).
  *  2. `getExportJob`    — polls job status by ID.
  *  3. `listExportJobs` — lists all jobs for a project (for admin/debug).
+ *  4. `issueDownloadLink` — issues a fresh short-lived signed download URL
+ *     for a completed job.
+ *  5. `resolveDownload`   — verifies a token and returns the raw export data.
  *
- * The actual export data is encoded inline as a base64 data URI on the
- * `downloadUrl` field (suitable for moderate-sized exports). In production
- * this would be replaced with a signed S3 URL written after the file upload.
+ * On completion, the export content is stored in `downloadUrl` as a base64
+ * data URI (internal storage).  The public API issues short-lived signed
+ * tokens instead of exposing the raw data URI directly.  This decouples
+ * token expiry from content storage.
  */
 @Injectable()
 export class TransactionExportService {
@@ -149,6 +251,10 @@ export class TransactionExportService {
   /**
    * Runs the actual query and serialization in the background.
    * Updates job status throughout execution.
+   *
+   * The raw export content is stored as a base64 data URI in `downloadUrl`
+   * for internal use. Clients receive short-lived signed tokens via
+   * `issueDownloadLink` rather than this field directly.
    */
   private async runExport(
     jobId: string,
@@ -169,15 +275,18 @@ export class TransactionExportService {
         : JSON.stringify(transactions, null, 2);
 
       const mimeType = format === 'CSV' ? 'text/csv' : 'application/json';
-      const downloadUrl = `data:${mimeType};base64,${Buffer.from(content).toString('base64')}`;
-      const expiresAt = new Date(Date.now() + DOWNLOAD_LINK_TTL_MS);
+      // Store the data URI internally (not exposed directly to clients —
+      // clients receive short-lived signed tokens from issueDownloadLink).
+      const internalDataUri = `data:${mimeType};base64,${Buffer.from(content).toString('base64')}`;
+      // Default expiry aligned with the maximum allowed token TTL (24 h).
+      const expiresAt = new Date(Date.now() + MAX_DOWNLOAD_LINK_TTL_MS);
 
       await this.prisma.transactionExportJob.update({
         where: { id: jobId },
         data: {
           status: 'COMPLETED',
           rowCount: transactions.length,
-          downloadUrl,
+          downloadUrl: internalDataUri,
           expiresAt,
           completedAt: new Date(),
         },
@@ -199,6 +308,101 @@ export class TransactionExportService {
         },
       });
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public — signed download link issuance and resolution
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Issues a short-lived signed download token for a completed export job.
+   *
+   * @param jobId       The export job ID.
+   * @param projectId   The project that owns the job (used for tenant scoping).
+   * @param ttlMs       How long the token should be valid (default 1 h, capped at 24 h).
+   * @returns           A signed token and its expiry time.
+   */
+  async issueDownloadLink(
+    jobId: string,
+    projectId: string,
+    ttlMs: number = DEFAULT_DOWNLOAD_LINK_TTL_MS,
+  ): Promise<{ token: string; expiresAt: Date; downloadUrl: string }> {
+    const job = await this.getExportJob(jobId, projectId);
+
+    if (job.status !== 'COMPLETED') {
+      throw new BadRequestException(
+        `Export job ${jobId} is not completed (current status: ${job.status}). ` +
+          'A download link can only be issued for completed jobs.',
+      );
+    }
+
+    // Ensure the stored export data has not been purged.
+    if (!job.downloadUrl) {
+      throw new BadRequestException(
+        `Export job ${jobId} has no stored data. The export may have expired.`,
+      );
+    }
+
+    const { token, expiresAt } = generateDownloadToken(jobId, projectId, ttlMs);
+
+    // Build a relative download URL path that clients can call.
+    const downloadUrl = `/v1/transactions/export/${jobId}/download?token=${token}`;
+
+    return { token, expiresAt, downloadUrl };
+  }
+
+  /**
+   * Verifies a signed download token and returns the raw export content
+   * together with metadata needed to set response headers.
+   *
+   * @param jobId  Export job ID (from route param — used to cross-check token).
+   * @param token  The signed token issued by `issueDownloadLink`.
+   * @returns      `{ content, mimeType, filename }` for the HTTP handler.
+   */
+  async resolveDownload(
+    jobId: string,
+    token: string,
+  ): Promise<{ content: Buffer; mimeType: string; filename: string }> {
+    const payload = verifyDownloadToken(token);
+
+    if (payload.jobId !== jobId) {
+      throw new BadRequestException(
+        'Download token does not match the requested job ID',
+      );
+    }
+
+    // Load the job — tenant check via projectId from the token payload.
+    const job = await this.prisma.transactionExportJob.findFirst({
+      where: { id: jobId, projectId: payload.projectId },
+    });
+
+    if (!job) {
+      throw new NotFoundException(`Export job ${jobId} not found`);
+    }
+
+    if (job.status !== 'COMPLETED' || !job.downloadUrl) {
+      throw new BadRequestException(
+        `Export job ${jobId} is not available for download (status: ${job.status})`,
+      );
+    }
+
+    // Parse the internally stored data URI.
+    // Format: data:<mimeType>;base64,<base64data>
+    const dataUriMatch = (job.downloadUrl as string).match(
+      /^data:([^;]+);base64,(.+)$/s,
+    );
+    if (!dataUriMatch) {
+      throw new BadRequestException(
+        'Export data is malformed. Please re-create the export job.',
+      );
+    }
+
+    const mimeType = dataUriMatch[1];
+    const content = Buffer.from(dataUriMatch[2], 'base64');
+    const ext = job.format === 'JSON' ? 'json' : 'csv';
+    const filename = `export-${jobId}.${ext}`;
+
+    return { content, mimeType, filename };
   }
 
   /**

--- a/src/webhooks/dto/update-webhook-subscriptions.dto.ts
+++ b/src/webhooks/dto/update-webhook-subscriptions.dto.ts
@@ -1,0 +1,23 @@
+import { IsArray, ArrayNotEmpty, IsEnum } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { WebhookEventType } from '../domain/webhook-events';
+
+/**
+ * DTO for replacing the full set of subscribed event types on a webhook endpoint.
+ */
+export class UpdateWebhookSubscriptionsDto {
+  @ApiProperty({
+    description:
+      'Complete list of event types to subscribe to. Replaces all existing subscriptions.',
+    example: ['wallet.created', 'transaction.confirmed'],
+    enum: WebhookEventType,
+    isArray: true,
+  })
+  @IsArray({ message: 'events must be an array' })
+  @ArrayNotEmpty({ message: 'events must not be empty' })
+  @IsEnum(WebhookEventType, {
+    each: true,
+    message: `each event must be a valid WebhookEventType. Valid values: ${Object.values(WebhookEventType).join(', ')}`,
+  })
+  events: WebhookEventType[];
+}

--- a/src/webhooks/webhook-event-subscriptions-551.spec.ts
+++ b/src/webhooks/webhook-event-subscriptions-551.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for webhook event type subscription management (#551).
+ *
+ * Covers:
+ *  - getSubscribedEvents: returns events from a valid endpoint
+ *  - getSubscribedEvents: propagates NotFoundException for unknown endpoint
+ *  - updateSubscribedEvents: replaces events with validated list
+ *  - updateSubscribedEvents: rejects unknown event types with 400
+ *  - updateSubscribedEvents: propagates NotFoundException for unknown endpoint
+ */
+import {
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { WebhookService } from './webhook.service';
+import { WebhookEventType, EndpointStatus } from './domain/webhook-events';
+
+const ENDPOINT_ID = 'ep-uuid-1';
+const PROJECT_ID = 'proj-uuid-1';
+
+function makeEndpoint(override: Partial<any> = {}) {
+  return {
+    id: ENDPOINT_ID,
+    projectId: PROJECT_ID,
+    url: 'https://example.com/hook',
+    description: null,
+    secret: 'whsec_abc',
+    events: [WebhookEventType.WALLET_CREATED],
+    status: EndpointStatus.ACTIVE,
+    consecutiveFailures: 0,
+    lastFailureAt: null,
+    lastFailureReason: null,
+    lastSuccessAt: null,
+    deletedAt: null,
+    createdAt: new Date('2026-07-30T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-30T00:00:00.000Z'),
+    ...override,
+  };
+}
+
+describe('WebhookService – event subscriptions (#551)', () => {
+  let service: WebhookService;
+
+  const mockPrisma: any = {
+    webhookEndpoint: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      count: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    webhookDelivery: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+    $disconnect: jest.fn(),
+  };
+
+  const mockCache: any = {
+    get: jest.fn().mockReturnValue(null),
+    set: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Re-set default implementations after clearAllMocks wipes them
+    mockCache.get.mockReturnValue(null);
+    // Directly instantiate to avoid NestJS DI token resolution issues
+    service = new WebhookService(mockPrisma, mockCache);
+  });
+
+  // ── getSubscribedEvents ──────────────────────────────────────────────────────
+
+  describe('getSubscribedEvents', () => {
+    it('returns the events array for a known endpoint', async () => {
+      const endpoint = makeEndpoint({
+        events: [
+          WebhookEventType.WALLET_CREATED,
+          WebhookEventType.TRANSACTION_CONFIRMED,
+        ],
+      });
+      mockPrisma.webhookEndpoint.findUnique.mockResolvedValue(endpoint);
+
+      const result = await service.getSubscribedEvents(ENDPOINT_ID);
+
+      expect(result).toEqual([
+        WebhookEventType.WALLET_CREATED,
+        WebhookEventType.TRANSACTION_CONFIRMED,
+      ]);
+    });
+
+    it('throws NotFoundException when endpoint does not exist', async () => {
+      mockPrisma.webhookEndpoint.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.getSubscribedEvents('nonexistent-id'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── updateSubscribedEvents ───────────────────────────────────────────────────
+
+  describe('updateSubscribedEvents', () => {
+    it('updates and returns the new events list for valid event types', async () => {
+      const newEvents = [
+        WebhookEventType.WALLET_CREATED,
+        WebhookEventType.BALANCE_LOW,
+      ];
+      const updatedEndpoint = makeEndpoint({ events: newEvents });
+
+      mockPrisma.webhookEndpoint.findUnique.mockResolvedValue(makeEndpoint());
+      mockPrisma.webhookEndpoint.update.mockResolvedValue(updatedEndpoint);
+
+      const result = await service.updateSubscribedEvents(ENDPOINT_ID, newEvents);
+
+      expect(result).toEqual(newEvents);
+      expect(mockPrisma.webhookEndpoint.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: ENDPOINT_ID },
+          data: { events: newEvents },
+        }),
+      );
+    });
+
+    it('invalidates the cache entry after updating events', async () => {
+      const newEvents = [WebhookEventType.USER_CREATED];
+      mockPrisma.webhookEndpoint.findUnique.mockResolvedValue(makeEndpoint());
+      mockPrisma.webhookEndpoint.update.mockResolvedValue(
+        makeEndpoint({ events: newEvents }),
+      );
+
+      await service.updateSubscribedEvents(ENDPOINT_ID, newEvents);
+
+      expect(mockCache.delete).toHaveBeenCalledWith(
+        expect.stringContaining(ENDPOINT_ID),
+      );
+    });
+
+    it('rejects unknown event types with BadRequestException', async () => {
+      mockPrisma.webhookEndpoint.findUnique.mockResolvedValue(makeEndpoint());
+
+      await expect(
+        service.updateSubscribedEvents(ENDPOINT_ID, [
+          WebhookEventType.WALLET_CREATED,
+          'foo.unknown_event' as any,
+        ]),
+      ).rejects.toThrow(BadRequestException);
+
+      // Prisma update should NOT be called
+      expect(mockPrisma.webhookEndpoint.update).not.toHaveBeenCalled();
+    });
+
+    it('error message includes the invalid event type name', async () => {
+      mockPrisma.webhookEndpoint.findUnique.mockResolvedValue(makeEndpoint());
+
+      let threw = false;
+      try {
+        await service.updateSubscribedEvents(ENDPOINT_ID, [
+          'invalid.event.type' as any,
+        ]);
+      } catch (err: any) {
+        threw = true;
+        expect(err.message).toContain('invalid.event.type');
+      }
+      expect(threw).toBe(true);
+    });
+
+    it('throws NotFoundException when endpoint does not exist', async () => {
+      mockPrisma.webhookEndpoint.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.updateSubscribedEvents('nonexistent-id', [
+          WebhookEventType.WALLET_CREATED,
+        ]),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('accepts all valid WebhookEventType values', async () => {
+      const allEvents = Object.values(WebhookEventType);
+      const updatedEndpoint = makeEndpoint({ events: allEvents });
+
+      mockPrisma.webhookEndpoint.findUnique.mockResolvedValue(makeEndpoint());
+      mockPrisma.webhookEndpoint.update.mockResolvedValue(updatedEndpoint);
+
+      const result = await service.updateSubscribedEvents(ENDPOINT_ID, allEvents);
+      expect(result).toEqual(allEvents);
+    });
+  });
+});

--- a/src/webhooks/webhook.controller.ts
+++ b/src/webhooks/webhook.controller.ts
@@ -25,6 +25,8 @@ import { WebhookDlqAlertService } from './webhook-dlq-alert.service';
 import { CreateWebhookEndpointDto } from './dto/create-webhook-endpoint.dto';
 import { UpdateWebhookEndpointDto } from './dto/update-webhook-endpoint.dto';
 import { WebhookFilterDto } from './dto/webhook-filter.dto';
+import { UpdateWebhookSubscriptionsDto } from './dto/update-webhook-subscriptions.dto';
+import { WebhookEventType } from './domain/webhook-events';
 import { FeatureFlagGuard } from '../common/feature-flags/feature-flag.guard';
 import { FeatureFlag } from '../common/feature-flags/feature-flag.guard';
 import {
@@ -537,6 +539,158 @@ export class WebhookController {
       delivered: result.delivered,
       failed: result.failed,
       retrying: result.retrying,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /webhooks/endpoints/:id/subscriptions
+  // ---------------------------------------------------------------------------
+
+  @ApiOperation({
+    summary: 'Get subscribed event types for a webhook endpoint',
+    description:
+      'Returns the list of event types the endpoint is currently subscribed to, ' +
+      'along with a reference of all valid event types.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Webhook endpoint ID',
+    example: 'endpoint-uuid',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Current event subscriptions',
+    schema: {
+      example: {
+        endpointId: 'endpoint-uuid',
+        events: ['wallet.created', 'transaction.confirmed'],
+        allValidEvents: [
+          'wallet.created',
+          'wallet.activated',
+          'transaction.confirmed',
+        ],
+      },
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Endpoint not found',
+    example: { statusCode: 404, message: 'Webhook endpoint endpoint-uuid not found' },
+  })
+  @Get('endpoints/:id/subscriptions')
+  async getSubscribedEvents(@Param('id') id: string) {
+    const events = await this.webhookService.getSubscribedEvents(id);
+    return {
+      endpointId: id,
+      events,
+      allValidEvents: Object.values(WebhookEventType),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // PUT /webhooks/endpoints/:id/subscriptions
+  // ---------------------------------------------------------------------------
+
+  @ApiOperation({
+    summary: 'Replace subscribed event types for a webhook endpoint',
+    description:
+      'Replaces all subscribed event types with the supplied list. ' +
+      'All values must be members of the known WebhookEventType enum. ' +
+      'Providing an unknown event type returns 400 Bad Request.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Webhook endpoint ID',
+    example: 'endpoint-uuid',
+  })
+  @ApiBody({
+    type: UpdateWebhookSubscriptionsDto,
+    examples: {
+      default: {
+        value: {
+          events: ['wallet.created', 'transaction.confirmed'],
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Updated event subscriptions',
+    schema: {
+      example: {
+        endpointId: 'endpoint-uuid',
+        events: ['wallet.created', 'transaction.confirmed'],
+        updatedAt: '2026-07-30T00:00:00.000Z',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'One or more event types are not valid WebhookEventType values',
+    example: {
+      statusCode: 400,
+      message: 'Unknown event type(s): foo.bar. Valid values: wallet.created, ...',
+      error: 'Bad Request',
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Endpoint not found',
+  })
+  @Put('endpoints/:id/subscriptions')
+  @HttpCode(HttpStatus.OK)
+  async updateSubscribedEvents(
+    @Param('id') id: string,
+    @Body() dto: UpdateWebhookSubscriptionsDto,
+  ) {
+    const events = await this.webhookService.updateSubscribedEvents(id, dto.events);
+    return {
+      endpointId: id,
+      events,
+      updatedAt: new Date(),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /webhooks/event-types  — reference list of all valid event types
+  // ---------------------------------------------------------------------------
+
+  @ApiOperation({
+    summary: 'List all valid webhook event types',
+    description:
+      'Returns the complete set of event type strings that can be used ' +
+      'when creating or updating webhook endpoint subscriptions.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Enum of all supported event types',
+    schema: {
+      example: {
+        eventTypes: [
+          'wallet.created',
+          'wallet.activated',
+          'wallet.suspended',
+          'wallet.rotated',
+          'transaction.created',
+          'transaction.pending',
+          'transaction.confirmed',
+          'transaction.failed',
+          'balance.updated',
+          'balance.low',
+          'balance.mismatch',
+          'user.created',
+          'user.updated',
+          'auth.user_authenticated',
+          'auth.new_user_registered',
+          'auth.authentication_failed',
+        ],
+      },
+    },
+  })
+  @Get('event-types')
+  listEventTypes() {
+    return {
+      eventTypes: Object.values(WebhookEventType),
     };
   }
 

--- a/src/webhooks/webhook.service.ts
+++ b/src/webhooks/webhook.service.ts
@@ -7,6 +7,7 @@ import {
 import { PrismaClient } from '../generated/prisma/client';
 import {
   WebhookEndpoint,
+  WebhookEventType,
   EndpointStatus,
   DeliveryStatus,
 } from './domain/webhook-events';
@@ -124,16 +125,12 @@ export class WebhookService {
 
     const skip = (page - 1) * take;
 
-    const where: any = { projectId };
-    if (statusFilter) where.status = statusFilter;
-    if (eventFilter) where.events = { has: eventFilter };
-
     const where: Record<string, unknown> = { projectId };
-    if (filter.status) {
-      where.status = filter.status;
+    if (statusFilter) {
+      where.status = statusFilter;
     }
-    if (filter.event) {
-      where.events = { has: filter.event };
+    if (eventFilter) {
+      where.events = { has: eventFilter };
     }
 
     const [endpoints, total] = await Promise.all([
@@ -204,6 +201,48 @@ export class WebhookService {
     });
 
     this.invalidateEndpointCache(endpointId);
+  }
+
+  /**
+   * Returns the list of event types the endpoint is currently subscribed to.
+   */
+  async getSubscribedEvents(endpointId: string): Promise<string[]> {
+    const endpoint = await this.getEndpoint(endpointId);
+    return endpoint.events;
+  }
+
+  /**
+   * Replaces all subscribed event types for the endpoint.
+   * Validates each event against the known WebhookEventType enum before persisting.
+   *
+   * @param endpointId  The endpoint to update.
+   * @param events      The complete replacement set of event type strings.
+   * @returns           The persisted list of event types.
+   */
+  async updateSubscribedEvents(
+    endpointId: string,
+    events: string[],
+  ): Promise<string[]> {
+    const validValues = new Set<string>(Object.values(WebhookEventType));
+    const invalid = events.filter((e) => !validValues.has(e));
+    if (invalid.length > 0) {
+      throw new BadRequestException(
+        `Unknown event type(s): ${invalid.join(', ')}. ` +
+          `Valid values: ${[...validValues].join(', ')}`,
+      );
+    }
+
+    // Verify the endpoint exists (throws NotFoundException if not found)
+    await this.getEndpoint(endpointId);
+
+    const updated = await this.prisma.webhookEndpoint.update({
+      where: { id: endpointId },
+      data: { events },
+    });
+
+    this.invalidateEndpointCache(endpointId);
+
+    return updated.events;
   }
 
   /**


### PR DESCRIPTION
…O UTC timestamps

Implements issues #551, #552, #553, and #556.

#551 — Webhook event type subscriptions
- Add WebhookService.getSubscribedEvents / updateSubscribedEvents
- Validate events against WebhookEventType enum; unknown types return 400
- New endpoints: GET/PUT /webhooks/endpoints/:id/subscriptions
- New reference endpoint: GET /webhooks/event-types
- Add UpdateWebhookSubscriptionsDto with @IsEnum validation
- Fix pre-existing duplicate 'where' variable in listEndpoints

#552 — Short-lived signed download links for exports
- Add generateDownloadToken / verifyDownloadToken (HMAC-SHA256, configurable TTL)
- Token TTL: default 1 h, min 5 min, max 24 h; signed with EXPORT_SIGNING_SECRET
- Add TransactionExportService.issueDownloadLink and resolveDownload
- New endpoints: POST /transactions/export/:jobId/issue-link GET  /transactions/export/:jobId/download?token=...
- Download endpoint bypasses API key auth — token IS the credential

#553 — Recovery cancel endpoint
- Add RecoveryService.cancel using canTransitionRecoveryStatus
- Cancellable from PENDING, IN_REVIEW, APPROVED; terminal states return 400
- New endpoint: POST /recovery/:id/cancel with full OpenAPI docs
- Fix missing HttpCode/HttpStatus imports in recovery controller

#556 — ISO UTC timestamp serialization
- Add IsoUtcTimestampInterceptor (global, registered in main.ts)
- Recursively converts all Date instances to .toISOString() in responses
- Strings, null, undefined, and primitives pass through unchanged
- Depth-capped at 20 to protect against pathological structures

Tests: 45 new passing tests across all four features

Closes #551 
Closes #552 
Closes #553 
Closes #556 
