### PR TITLE
Standardize wallet limits, error envelope, and Prisma migration hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Generate Prisma client
         run: pnpm prisma:generate
 
+      - name: Check Prisma migration naming
+        run: pnpm run prisma:check-migrations
+
       - name: Build
         run: pnpm run build
 
@@ -64,3 +67,6 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: Test scripts
+        run: pnpm run test:scripts

--- a/README.md
+++ b/README.md
@@ -35,6 +35,31 @@ It handles wallet creation, transaction orchestration, fee sponsorship, and on-c
 
 All routes below are served under the `/v1` prefix (e.g. `GET /v1/health`). See [docs/API-VERSIONING.md](docs/API-VERSIONING.md) for the versioning strategy.
 
+### Error responses
+
+Every error — thrown `HttpException`, unhandled exception, or validation
+failure — is returned by a global exception filter in the same structured
+envelope:
+
+```json
+{
+  "statusCode": 422,
+  "timestamp": "2026-07-30T12:34:56.789Z",
+  "path": "/v1/wallets/123/limits",
+  "method": "POST",
+  "message": "Per-transaction limit exceeded. Limit: 1000",
+  "error": "Unprocessable Entity",
+  "errorCode": "LIMIT_PER_TX_EXCEEDED",
+  "requestId": "..."
+}
+```
+
+`error` and `message` are always present. `errorCode` (a stable, machine-readable
+string) and `details` (a structured object) are included only when the thrown
+exception provides them. `requestId` is echoed back from the `X-Request-ID`
+request header when present. In production, `message` on unhandled 500 errors
+is sanitized to strip connection strings, file paths, and secrets.
+
 ### Request body size
 
 JSON and URL-encoded request bodies are limited to 100 KiB by default. Set

--- a/docs/PRISMA-MIGRATIONS.md
+++ b/docs/PRISMA-MIGRATIONS.md
@@ -1,0 +1,47 @@
+# Prisma migration conventions
+
+## Naming
+
+Every migration must live in its own folder directly under `prisma/migrations/`:
+
+```
+prisma/migrations/20260730120000_add_thing/migration.sql
+```
+
+- Folder name: `<14-digit-timestamp>_<snake_case_description>` — the format
+  `prisma migrate dev` generates by default. The timestamp must be unique and
+  should reflect when the migration was authored (`YYYYMMDDHHMMSS`).
+- The folder must contain a `migration.sql` file. Don't drop loose `.sql`
+  files directly under `prisma/migrations/` — Prisma silently ignores
+  anything that isn't inside a migration folder, so a stray file never gets
+  applied by `prisma migrate deploy` even though it looks like it's part of
+  the migration history.
+- `migration_lock.toml` is the only file allowed directly under
+  `prisma/migrations/`.
+
+A number of early migrations predate this convention — some use a bare
+counter (`0_init`), a short date without a time component
+(`20260602_add_wallet_key_version`), or reuse the same 14-digit timestamp as
+another migration. They're already applied in every environment, so renaming
+them would break Prisma's `_prisma_migrations` tracking table. They're listed
+by name in the `LEGACY_EXCEPTIONS` set in `scripts/check-migration-naming.ts`
+(the source of truth) and must not be used as a template for new migrations.
+
+## CI check
+
+`pnpm run prisma:check-migrations` (wired into `.github/workflows/ci.yml`)
+verifies:
+
+- no loose files under `prisma/migrations/` other than `migration_lock.toml`
+- every migration folder contains a `migration.sql`
+- every non-legacy folder matches the naming pattern above
+- no two non-legacy migrations reuse the same timestamp
+
+Run it locally before opening a PR that touches `prisma/migrations/`:
+
+```
+pnpm run prisma:check-migrations
+```
+
+The validation logic is unit tested in `scripts/check-migration-naming.spec.ts`
+(`pnpm run test:scripts`).

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "preinstall": "npx only-allow pnpm",
     "openapi:generate": "ts-node -r tsconfig-paths/register scripts/generate-openapi.ts",
-    "openapi:lint": "npx @redocly/cli@latest lint openapi.json --config redocly.yaml"
+    "openapi:lint": "npx @redocly/cli@latest lint openapi.json --config redocly.yaml",
+    "prisma:check-migrations": "ts-node -r tsconfig-paths/register scripts/check-migration-naming.ts",
+    "test:scripts": "jest --config scripts/jest.config.js"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/prisma/migrations/20260730000000_add_network_scoped_api_keys/migration.sql
+++ b/prisma/migrations/20260730000000_add_network_scoped_api_keys/migration.sql
@@ -1,5 +1,5 @@
 -- AlterTable
-ALTER TABLE "ApiKey" ADD COLUMN "network" TEXT;
+ALTER TABLE "ApiKey" ADD COLUMN "network" "WalletNetwork";
 
 -- CreateIndex
 CREATE INDEX "ApiKey_network_idx" ON "ApiKey"("network");

--- a/scripts/check-migration-naming.spec.ts
+++ b/scripts/check-migration-naming.spec.ts
@@ -1,0 +1,78 @@
+import { validateMigrationEntries, MigrationEntry } from './check-migration-naming';
+
+function dir(name: string, hasMigrationSql = true): MigrationEntry {
+  return { name, isDirectory: true, hasMigrationSql };
+}
+
+function file(name: string): MigrationEntry {
+  return { name, isDirectory: false, hasMigrationSql: false };
+}
+
+describe('validateMigrationEntries', () => {
+  it('passes for a well-formed set of migrations plus the lock file', () => {
+    const errors = validateMigrationEntries([
+      file('migration_lock.toml'),
+      dir('20260601000000_add_thing'),
+      dir('20260602000000_add_other_thing'),
+    ]);
+    expect(errors).toEqual([]);
+  });
+
+  it('grandfathers known legacy folder names without a timestamp prefix', () => {
+    const errors = validateMigrationEntries([
+      dir('0_init'),
+      dir('1_add_wallet_limit'),
+      dir('20260602_add_wallet_key_version'),
+    ]);
+    expect(errors).toEqual([]);
+  });
+
+  it('fails on a loose file directly under prisma/migrations', () => {
+    const errors = validateMigrationEntries([
+      file('network_scoped_api_keys.sql'),
+    ]);
+    expect(errors).toEqual([
+      expect.stringContaining('network_scoped_api_keys.sql'),
+    ]);
+  });
+
+  it('fails on a migration folder missing migration.sql', () => {
+    const errors = validateMigrationEntries([
+      dir('20260601000000_add_thing', false),
+    ]);
+    expect(errors).toEqual([
+      expect.stringContaining('missing a migration.sql file'),
+    ]);
+  });
+
+  it('fails on a new (non-legacy) folder that does not match the naming pattern', () => {
+    const errors = validateMigrationEntries([dir('add_thing_without_timestamp')]);
+    expect(errors).toEqual([
+      expect.stringContaining('does not match the required'),
+    ]);
+  });
+
+  it('fails on a non-legacy folder using an unpadded/short timestamp', () => {
+    const errors = validateMigrationEntries([dir('20260602_add_wallet_key_version_v2')]);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain('does not match the required');
+  });
+
+  it('fails when two non-legacy migrations reuse the same timestamp', () => {
+    const errors = validateMigrationEntries([
+      dir('20260601000000_add_thing'),
+      dir('20260601000000_add_other_thing'),
+    ]);
+    expect(errors).toEqual([
+      expect.stringContaining('reuses timestamp 20260601000000'),
+    ]);
+  });
+
+  it('does not flag duplicate timestamps between two legacy-exception folders', () => {
+    const errors = validateMigrationEntries([
+      dir('0_init'),
+      dir('1_add_wallet_limit'),
+    ]);
+    expect(errors).toEqual([]);
+  });
+});

--- a/scripts/check-migration-naming.ts
+++ b/scripts/check-migration-naming.ts
@@ -1,0 +1,120 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const MIGRATIONS_DIR = path.join(__dirname, '..', 'prisma', 'migrations');
+
+/** Files permitted to sit directly under prisma/migrations/ (not inside a migration folder). */
+export const ALLOWED_TOP_LEVEL_FILES = new Set(['migration_lock.toml']);
+
+/**
+ * Migration folders created before this naming convention was enforced.
+ * They are already applied to real databases, so they can't be renamed
+ * without breaking Prisma's `_prisma_migrations` tracking table. New
+ * migrations must not be added to this list.
+ */
+export const LEGACY_EXCEPTIONS = new Set([
+  '0_init',
+  '1_add_wallet_limit',
+  '20260601000000_add_spending_limits',
+  '20260601000000_add_transaction_idempotency_key',
+  '20260601000000_add_wallet_successor_id',
+  '20260602_add_wallet_key_version',
+  '20260723_add_asset_code_to_payment',
+  '20260724000000_add_user_default_network',
+  '20260724000000_add_user_last_login_metadata',
+  '20260724_add_soft_delete_to_wallet_limit',
+  '20260729000000_add_maintenance_state',
+  '20260729000000_add_wallet_nickname',
+]);
+
+const NAME_PATTERN = /^\d{14}_[a-z0-9_]+$/;
+
+export interface MigrationEntry {
+  name: string;
+  isDirectory: boolean;
+  hasMigrationSql: boolean;
+}
+
+/**
+ * Pure validation over a directory listing so the rules can be unit tested
+ * without touching the filesystem.
+ */
+export function validateMigrationEntries(entries: MigrationEntry[]): string[] {
+  const errors: string[] = [];
+  const seenTimestamps = new Map<string, string>();
+
+  for (const entry of entries) {
+    if (!entry.isDirectory) {
+      if (!ALLOWED_TOP_LEVEL_FILES.has(entry.name)) {
+        errors.push(
+          `"${entry.name}" is a loose file directly under prisma/migrations/. ` +
+            `Every migration must live in its own "<timestamp>_<name>/migration.sql" folder.`,
+        );
+      }
+      continue;
+    }
+
+    if (!entry.hasMigrationSql) {
+      errors.push(
+        `"${entry.name}/" is missing a migration.sql file.`,
+      );
+    }
+
+    if (LEGACY_EXCEPTIONS.has(entry.name)) {
+      continue;
+    }
+
+    if (!NAME_PATTERN.test(entry.name)) {
+      errors.push(
+        `"${entry.name}" does not match the required "<14-digit-timestamp>_<snake_case_name>" ` +
+          `format (e.g. 20260730120000_add_thing). See docs/PRISMA-MIGRATIONS.md.`,
+      );
+      continue;
+    }
+
+    const timestamp = entry.name.slice(0, 14);
+    const clash = seenTimestamps.get(timestamp);
+    if (clash) {
+      errors.push(
+        `"${entry.name}" reuses timestamp ${timestamp} already used by "${clash}". ` +
+          `Migration timestamps must be unique and monotonically increasing.`,
+      );
+    } else {
+      seenTimestamps.set(timestamp, entry.name);
+    }
+  }
+
+  return errors;
+}
+
+function readEntries(dir: string): MigrationEntry[] {
+  return fs.readdirSync(dir).map((name) => {
+    const full = path.join(dir, name);
+    const isDirectory = fs.statSync(full).isDirectory();
+    const hasMigrationSql =
+      isDirectory && fs.existsSync(path.join(full, 'migration.sql'));
+    return { name, isDirectory, hasMigrationSql };
+  });
+}
+
+function main() {
+  const entries = readEntries(MIGRATIONS_DIR);
+  const errors = validateMigrationEntries(entries);
+
+  if (errors.length > 0) {
+    console.error('Prisma migration naming check failed:\n');
+    for (const error of errors) {
+      console.error(`  - ${error}`);
+    }
+    console.error(
+      '\nSee docs/PRISMA-MIGRATIONS.md for the naming convention and how to fix this.',
+    );
+    process.exit(1);
+  }
+
+  console.log(`Prisma migration naming check passed (${entries.length} entries).`);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/jest.config.js
+++ b/scripts/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  rootDir: '.',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  testEnvironment: 'node',
+};

--- a/src/common/filters/http-exception.filter.spec.ts
+++ b/src/common/filters/http-exception.filter.spec.ts
@@ -388,6 +388,27 @@ describe('HttpExceptionFilter', () => {
       const jsonCall = mockResponse.json.mock.calls[0][0];
       expect(jsonCall.details).toBeUndefined();
     });
+
+    it('should include errorCode field when provided on the exception body', () => {
+      const exception = new HttpException(
+        { errorCode: 'LIMIT_PER_TX_EXCEEDED', message: 'Per-transaction limit exceeded' },
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      );
+
+      filter.catch(exception, mockArgumentsHost);
+
+      const jsonCall = mockResponse.json.mock.calls[0][0];
+      expect(jsonCall.errorCode).toBe('LIMIT_PER_TX_EXCEEDED');
+    });
+
+    it('should not include errorCode field when not provided', () => {
+      const exception = new NotFoundException('Not found');
+
+      filter.catch(exception, mockArgumentsHost);
+
+      const jsonCall = mockResponse.json.mock.calls[0][0];
+      expect(jsonCall.errorCode).toBeUndefined();
+    });
   });
 
   describe('HTTP status code mapping', () => {

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -18,6 +18,7 @@ export interface ErrorResponse {
   method: string;
   message: string | string[];
   error?: string;
+  errorCode?: string;
   details?: Record<string, any>;
   requestId?: string;
 }
@@ -69,10 +70,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
       const exceptionResponse = exception.getResponse();
 
       // Extract message and details from exception response
-      const { message, error, details } = this.parseHttpExceptionResponse(
-        exceptionResponse,
-        status,
-      );
+      const { message, error, errorCode, details } =
+        this.parseHttpExceptionResponse(exceptionResponse, status);
 
       return {
         statusCode: status,
@@ -81,6 +80,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
         method,
         message,
         error,
+        ...(errorCode && { errorCode }),
         ...(details && { details }),
         ...(request.headers['x-request-id'] && {
           requestId: request.headers['x-request-id'] as string,
@@ -126,6 +126,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
   ): {
     message: string | string[];
     error: string;
+    errorCode?: string;
     details?: Record<string, any>;
   } {
     // If response is a string, use it as the message
@@ -142,6 +143,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
     return {
       message: responseObj.message || 'An error occurred',
       error: responseObj.error || this.getErrorNameFromStatus(status),
+      ...(responseObj.errorCode && { errorCode: responseObj.errorCode }),
       ...(responseObj.details && { details: responseObj.details }),
     };
   }

--- a/src/limits/limits.controller.ts
+++ b/src/limits/limits.controller.ts
@@ -19,6 +19,7 @@ import {
 } from '@nestjs/swagger';
 import { LimitsService } from './limits.service';
 import { SetLimitsDto } from './dto/set-limits.dto';
+import { UpdateLimitsDto } from './dto/update-limits.dto';
 import { LimitsResponseDto } from './dto/limits-response.dto';
 import {
   FeatureFlagGuard,
@@ -34,7 +35,7 @@ export class LimitsController {
 
   @ApiOperation({
     summary: 'Set wallet transaction and daily limits',
-    description: 'Set or update daily and per-transaction limits for a wallet. Requires API key authentication. Emits limit.updated events for each limit changed.',
+    description: 'Set or update daily and per-transaction limits for a wallet. The read-check and write are performed atomically in a single Prisma transaction, so concurrent requests for the same wallet cannot race. Requires API key authentication. Emits limit.updated events for each limit changed.',
   })
   @ApiParam({ name: 'walletId', description: 'Wallet ID (UUID)' })
   @ApiBody({

--- a/src/limits/limits.service.spec.ts
+++ b/src/limits/limits.service.spec.ts
@@ -22,12 +22,13 @@ describe('LimitsService', () => {
       walletLimit: {
         upsert: jest.fn(),
         findUnique: jest.fn(),
-        delete: jest.fn(),
+        update: jest.fn(),
       },
       transaction: {
         findMany: jest.fn(),
       },
     };
+    prisma.$transaction = jest.fn((cb) => cb(prisma));
     eventEmitter = { emit: jest.fn() };
     metrics = {
       incrementLimitExceeded: jest.fn(),
@@ -59,29 +60,41 @@ describe('LimitsService', () => {
       await service.setLimits(walletId, 100, 10);
       expect(prisma.walletLimit.upsert).toHaveBeenCalledWith({
         where: { walletId },
-        update: { dailyLimit: 100, perTransactionLimit: 10 },
+        update: { dailyLimit: 100, perTransactionLimit: 10, deletedAt: null },
         create: { walletId, dailyLimit: 100, perTransactionLimit: 10 },
       });
     });
+
+    it('should run the existence check and upsert inside a single Prisma transaction', async () => {
+      await service.setLimits(walletId, 100, 10);
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(prisma.walletLimit.findUnique).toHaveBeenCalledWith({
+        where: { walletId },
+      });
+    });
+
+    it('should propagate failure and emit no events if the transaction fails', async () => {
+      prisma.$transaction.mockRejectedValue(new Error('deadlock'));
+      await expect(service.setLimits(walletId, 100, 10)).rejects.toThrow(
+        'deadlock',
+      );
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
+    }, 10000);
   });
 
   describe('getLimits', () => {
     it('should return limits for a wallet', async () => {
       const limit = { walletId, dailyLimit: 100, perTransactionLimit: 10 };
       prisma.walletLimit.findUnique.mockResolvedValue(limit);
+      prisma.transaction.findMany.mockResolvedValue([]);
       const result = await service.getLimits(walletId);
-      expect(result).toEqual(limit);
+      expect(result).toEqual({ ...limit, remainingDailyLimit: 100 });
     });
 
-    it('should use the cache layer for wallet limits', async () => {
-      const limit = { walletId, dailyLimit: 100, perTransactionLimit: 10 };
-      cacheService.get.mockReturnValue(limit);
-
+    it('should return null when no limits exist for a wallet', async () => {
+      prisma.walletLimit.findUnique.mockResolvedValue(null);
       const result = await service.getLimits(walletId);
-
-      expect(result).toEqual(limit);
-      expect(cacheService.get).toHaveBeenCalledWith(`limits:${walletId}`);
-      expect(prisma.walletLimit.findUnique).not.toHaveBeenCalled();
+      expect(result).toBeNull();
     });
   });
 
@@ -96,6 +109,7 @@ describe('LimitsService', () => {
         perTransactionLimit: 50,
         dailyLimit: 1000,
       });
+      prisma.transaction.findMany.mockResolvedValue([]);
       await expect(service.checkLimits(walletId, 100)).rejects.toBeInstanceOf(
         LimitExceededException,
       );
@@ -168,13 +182,18 @@ describe('LimitsService', () => {
   });
 
   describe('removeLimits', () => {
-    it('should delete limits for a wallet', async () => {
+    it('should soft-delete limits for a wallet', async () => {
       const limit = { walletId, dailyLimit: 100, perTransactionLimit: 10 };
       prisma.walletLimit.findUnique.mockResolvedValue(limit);
-      prisma.walletLimit.delete.mockResolvedValue(limit);
+      prisma.transaction.findMany.mockResolvedValue([]);
+      prisma.walletLimit.update.mockResolvedValue({
+        ...limit,
+        deletedAt: new Date(),
+      });
       await service.removeLimits(walletId);
-      expect(prisma.walletLimit.delete).toHaveBeenCalledWith({
+      expect(prisma.walletLimit.update).toHaveBeenCalledWith({
         where: { walletId },
+        data: { deletedAt: expect.any(Date) },
       });
     });
 
@@ -193,6 +212,7 @@ describe('LimitsService', () => {
           perTransactionLimit: 50,
           dailyLimit: 1000,
         });
+        prisma.transaction.findMany.mockResolvedValue([]);
 
         try {
           await service.checkLimits(walletId, 100);

--- a/src/limits/limits.service.ts
+++ b/src/limits/limits.service.ts
@@ -50,22 +50,28 @@ export class LimitsService {
   ) {}
 
   async setLimits(walletId: string, daily: number, perTx: number) {
-    const existing = await retryWithBackoff(
+    // Read-then-write is wrapped in a single Prisma transaction so a
+    // concurrent setLimits call for the same wallet can't interleave
+    // between the existence check and the upsert, which would otherwise
+    // produce incorrect limit.updated diffs (comparing against stale data).
+    const { existing, result } = await retryWithBackoff(
       () =>
-        this.prisma.walletLimit.findUnique({
-          where: { walletId },
-        }),
-      3,
-      100,
-      this.logger,
-    );
+        this.prisma.$transaction(async (tx) => {
+          const existing = await tx.walletLimit.findUnique({
+            where: { walletId },
+          });
 
-    const result = await retryWithBackoff(
-      () =>
-        this.prisma.walletLimit.upsert({
-          where: { walletId },
-          update: { dailyLimit: daily, perTransactionLimit: perTx, deletedAt: null },
-          create: { walletId, dailyLimit: daily, perTransactionLimit: perTx },
+          const result = await tx.walletLimit.upsert({
+            where: { walletId },
+            update: {
+              dailyLimit: daily,
+              perTransactionLimit: perTx,
+              deletedAt: null,
+            },
+            create: { walletId, dailyLimit: daily, perTransactionLimit: perTx },
+          });
+
+          return { existing, result };
         }),
       3,
       100,

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { AppModule } from './app.module';
 import requestLogger from './common/middleware/request-logging.middleware';
 import { configureBodySizeLimit } from './common/http/body-size-limit';
 import { validateEnv } from './config/env.validation';
+import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 
 /**
  * Parses the CORS_ALLOWED_ORIGINS env var into an array of allowed origins.
@@ -61,6 +62,10 @@ async function bootstrap() {
       forbidNonWhitelisted: true,
     }),
   );
+
+  // Ensure every error response (thrown HttpException, unhandled Error, or
+  // unknown value) is returned in the same structured envelope.
+  app.useGlobalFilters(new HttpExceptionFilter());
 
   // Let Nest call onModuleDestroy/beforeApplicationShutdown on SIGTERM/SIGINT
   // so in-flight requests can finish and connections (Prisma, etc.) close cleanly.

--- a/src/payments/payments-limits.integration.spec.ts
+++ b/src/payments/payments-limits.integration.spec.ts
@@ -10,6 +10,8 @@ import { RequestContextService } from '../common/request-context/request-context
 import { PAYMENT_LIMITS_PORT } from './ports/payment-limits.port';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MetricsService } from '../metrics/metrics.service';
+import { PaymentMetricsService } from './payment-metrics.service';
+import { ConfigService } from '@nestjs/config';
 
 describe('Payments and Limits Integration', () => {
   let paymentsService: PaymentsService;
@@ -28,6 +30,7 @@ describe('Payments and Limits Integration', () => {
     payment: { create: jest.fn(), findMany: jest.fn() },
     transaction: { findMany: jest.fn() },
     legacyUser: {},
+    $transaction: jest.fn((cb: any) => cb(mockPrisma)),
   };
 
   const mockWalletsService = {
@@ -61,6 +64,8 @@ describe('Payments and Limits Integration', () => {
             incrementLimitChecks: jest.fn(),
           },
         },
+        PaymentMetricsService,
+        { provide: ConfigService, useValue: { get: jest.fn() } },
       ],
     }).compile();
 
@@ -145,6 +150,7 @@ describe('Payments and Limits Integration', () => {
       const limit = { walletId: testWalletId, dailyLimit: 1000, perTransactionLimit: 500 };
 
       mockPrisma.walletLimit.findUnique.mockResolvedValue(limit);
+      mockPrisma.transaction.findMany.mockResolvedValue([]);
 
       const result = await limitsService.getLimits(testWalletId);
 
@@ -173,6 +179,7 @@ describe('Payments and Limits Integration', () => {
         .mockResolvedValueOnce(senderWallet)
         .mockResolvedValueOnce(receiverWallet);
       mockPrisma.walletLimit.findUnique.mockResolvedValue(limit);
+      mockPrisma.transaction.findMany.mockResolvedValue([]);
 
       const createPaymentDto = {
         walletId: testWalletId,


### PR DESCRIPTION
## Summary

Closes #502
Closes #503 
Closes #514 
Closes #523.

### #502 — Replace legacy user limits with wallet scoped limits
- Verified `WalletLimit` (Prisma model), `LimitsService`, and `LimitsController` already implement full wallet-scoped CRUD with soft-delete, domain events, metrics, and OpenAPI docs; legacy `UserLimit`/`LegacyUser` are unreferenced outside `schema.prisma`.
- Fixed `limits.controller.ts` referencing `UpdateLimitsDto` in a `@ApiBody` decorator without importing it — a `ReferenceError` that crashed the module at load time.
- Fixed `payments-limits.integration.spec.ts`, which failed to instantiate `PaymentsService` because `PaymentMetricsService`/`ConfigService` providers were never added after those constructor deps were introduced.
- Rewrote stale assertions in `limits.service.spec.ts` that no longer matched the real implementation (asserted hard `delete` instead of soft-delete, referenced an undefined `cacheService`, missing `transaction.findMany` mocks for `remainingDailyLimit`).

### #503 — Create spending limits with Prisma transactions
- `LimitsService.setLimits` now wraps its read-then-write (`findUnique` + `upsert`) in a single `prisma.$transaction(...)`, closing a race window where two concurrent `setLimits` calls for the same wallet could read the same "existing" state and emit incorrect `limit.updated` diffs.
- Added tests: transaction invoked exactly once per call, and a transaction failure propagates with zero events emitted.
- Updated OpenAPI description on `POST /wallets/:walletId/limits` to document the atomicity guarantee.

### #514 — Standardize structured API error responses
- The fully-built, fully-tested `HttpExceptionFilter` was never registered — no `app.useGlobalFilters()` call existed anywhere, so real requests bypassed it entirely. Wired it into `main.ts`.
- Fixed a contract gap: the filter dropped `errorCode` from exception bodies (e.g. `LimitExceededException`'s `LIMIT_PER_TX_EXCEEDED`) even though the limits controller's own OpenAPI examples document it. Added `errorCode` to `ErrorResponse` and the parsing logic.
- Documented the standardized error envelope shape in `README.md`.

### #523 — Normalize Prisma migration docs and CI check
- Found `prisma/migrations/network_scoped_api_keys.sql` sitting as a loose file directly under `prisma/migrations/` — Prisma silently ignores anything not inside a migration folder, so the `ApiKey.network` column already declared in `schema.prisma` had **no migration that actually created it** (and the stray file used the wrong type, `TEXT` instead of the `WalletNetwork` enum). Moved it into a proper `20260730000000_add_network_scoped_api_keys/migration.sql` with the corrected enum type.
- Added `scripts/check-migration-naming.ts`: validates no loose files besides `migration_lock.toml`, every folder has a `migration.sql`, names match `<14-digit-timestamp>_<snake_case>`, and no duplicate timestamps — with a documented `LEGACY_EXCEPTIONS` allowlist for pre-existing folders already applied to real databases.
- Wired the check into CI (`.github/workflows/ci.yml`), plus a scoped Jest config (`scripts/jest.config.js`) for the checker's own unit tests.
- Added `docs/PRISMA-MIGRATIONS.md` documenting the convention.

## Test plan

- [x] `pnpm test` — all touched suites pass (`limits.service.spec.ts`, `limits.controller.spec.ts`, `payments-limits.integration.spec.ts`, `http-exception.filter.spec.ts`)
- [x] `pnpm run test:scripts` — 8/8 passing for the new migration-naming checker
- [x] `pnpm run prisma:check-migrations` — passes against current repo state
- [x] `npx prisma validate` — schema valid
- [x] `tsc --noEmit` clean on all touched files