### PR TITLE
Add Stellar address validation, mainnet payment kill-switch, build SHA in health check, and consolidated auth error messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ DATABASE_URL=postgresql://user:password@localhost:5432/mux_db?sslmode=require
 # ------------------------------------------------------------
 PORT=3000
 
+# Git commit SHA of the running build, exposed via GET /health for build
+# identity/traceability. Injected by CI/Docker (--build-arg GIT_SHA=...);
+# defaults to "unknown" if not set.
+GIT_SHA=
+
 # Maximum JSON/form request body size in bytes (default: 102400 / 100 KiB).
 # Requests above this limit receive HTTP 413.
 JSON_BODY_LIMIT_BYTES=102400

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/src/generated ./src/generated
 COPY prisma ./prisma
 
+# Build identity: pass --build-arg GIT_SHA=$(git rev-parse HEAD) so it's
+# exposed via GET /health. Defaults to "unknown" for local/dev builds.
+ARG GIT_SHA=unknown
+ENV GIT_SHA=$GIT_SHA
+
 EXPOSE 3000
 
 CMD ["node", "dist/main"]

--- a/docs/MAINNET-PAYMENT-FEATURE-FLAG.md
+++ b/docs/MAINNET-PAYMENT-FEATURE-FLAG.md
@@ -1,0 +1,13 @@
+# Mainnet Payment Submit Feature Flag
+
+- `FEATURE_MAINNET_PAYMENT_SUBMIT` (boolean, default: false)
+  - When `true`, `POST /transactions/fee-bump` requests with `network: "MAINNET"` are submitted to Horizon mainnet as normal.
+  - When `false` or unset, MAINNET submissions are rejected with HTTP 403 (Forbidden) and message: "Mainnet payment submission is not available at this time. (Flag: mainnet_payment_submit)". `TESTNET` submissions are unaffected — the flag is only consulted when `network === "MAINNET"`.
+
+Notes:
+- Implemented as a kill-switch check inside `FeeBumpService.submitFeeBump` (not the route-level `FeatureFlagGuard`), because the decision depends on the `network` field in the request body rather than being fixed per-route.
+- Reuses the existing `FeatureFlagService.isEnabled()` helper and the `FEATURE_<FLAG_NAME>` env var convention (e.g. `FEATURE_MAINNET_PAYMENT_SUBMIT=true`).
+- Rejections happen before any wallet key material is decrypted or any call to Horizon is made.
+
+Operational guidance:
+- Keep this flag off in production until mainnet payment submission has been reviewed and approved for general availability; flip it on per-environment via env/secret config.

--- a/src/auth/auth-metrics.integration.spec.ts
+++ b/src/auth/auth-metrics.integration.spec.ts
@@ -6,8 +6,15 @@
  * for every meaningful auth outcome.
  */
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, ForbiddenException } from '@nestjs/common';
-import { AuthOrchestrator } from './auth-orchestrator.service';
+import {
+  BadRequestException,
+  ForbiddenException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import {
+  AuthOrchestrator,
+  EXTERNAL_AUTH_FAILURE_MESSAGE,
+} from './auth-orchestrator.service';
 import { AuthMetricsService } from './auth-metrics.service';
 import { IdempotentUserService } from '../users/idempotent-user.service';
 import { WalletCreationOrchestrator } from '../wallets/wallet-creation-orchestrator.service';
@@ -202,12 +209,23 @@ describe('AuthOrchestrator — metrics integration', () => {
   });
 
   describe('unknown error', () => {
-    it('records failure_unknown for generic DB errors', async () => {
+    it('records failure_unknown for generic DB errors, without leaking the raw cause', async () => {
       userService.findOrCreateUser.mockRejectedValue(new Error('DB down'));
 
-      await expect(
-        orchestrator.handleAuthentication({ authId: 'auth-abc' }),
-      ).rejects.toThrow('Authentication failed: DB down');
+      let caught: unknown;
+      try {
+        await orchestrator.handleAuthentication({ authId: 'auth-abc' });
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(ServiceUnavailableException);
+      expect((caught as ServiceUnavailableException).message).toBe(
+        EXTERNAL_AUTH_FAILURE_MESSAGE,
+      );
+      expect((caught as ServiceUnavailableException).message).not.toContain(
+        'DB down',
+      );
 
       const snap = metricsService.getSnapshot();
       expect(snap.outcomes.failure_unknown).toBe(1);

--- a/src/auth/auth-orchestrator.controller.ts
+++ b/src/auth/auth-orchestrator.controller.ts
@@ -171,6 +171,21 @@ export class AuthOrchestratorController {
       },
     },
   })
+  @ApiResponse({
+    status: 503,
+    description:
+      'Service Unavailable — an unclassified downstream failure occurred ' +
+      '(e.g. database or Stellar network unreachable). The message is a ' +
+      'consolidated, generic string; internal error details are never ' +
+      'exposed to callers and are logged server-side only.',
+    schema: {
+      example: {
+        statusCode: 503,
+        message: 'Authentication failed. Please try again later.',
+        error: 'Service Unavailable',
+      },
+    },
+  })
   @Public()
   @Post('authenticate')
   @UseGuards(AuthRateLimitGuard)

--- a/src/auth/auth-orchestrator.integration.spec.ts
+++ b/src/auth/auth-orchestrator.integration.spec.ts
@@ -11,7 +11,11 @@
  * - Error propagation from collaborators
  */
 import { Test, TestingModule } from '@nestjs/testing';
-import { AuthOrchestrator } from './auth-orchestrator.service';
+import { ServiceUnavailableException } from '@nestjs/common';
+import {
+  AuthOrchestrator,
+  EXTERNAL_AUTH_FAILURE_MESSAGE,
+} from './auth-orchestrator.service';
 import { IdempotentUserService } from '../users/idempotent-user.service';
 import { WalletCreationOrchestrator } from '../wallets/wallet-creation-orchestrator.service';
 import { WalletNetwork, WalletStatus } from '../wallets/domain/wallet.model';
@@ -229,17 +233,28 @@ describe('AuthOrchestrator (integration harness)', () => {
   // -------------------------------------------------------------------------
 
   describe('error propagation', () => {
-    it('wraps user service errors in an Authentication failed error', async () => {
+    it('wraps user service errors in a consolidated, generic 503 — never leaking the raw cause', async () => {
       userService.findOrCreateUser.mockRejectedValue(
         new Error('DB unavailable'),
       );
 
-      await expect(
-        orchestrator.handleAuthentication({ authId: 'auth-abc' }),
-      ).rejects.toThrow('Authentication failed: DB unavailable');
+      let caught: unknown;
+      try {
+        await orchestrator.handleAuthentication({ authId: 'auth-abc' });
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(ServiceUnavailableException);
+      expect((caught as ServiceUnavailableException).message).toBe(
+        EXTERNAL_AUTH_FAILURE_MESSAGE,
+      );
+      expect((caught as ServiceUnavailableException).message).not.toContain(
+        'DB unavailable',
+      );
     });
 
-    it('wraps wallet creation errors in an Authentication failed error', async () => {
+    it('wraps wallet creation errors in a consolidated, generic 503 — never leaking the raw cause', async () => {
       userService.findOrCreateUser.mockResolvedValue({
         user: makeUser(),
         isNewUser: true,
@@ -249,9 +264,20 @@ describe('AuthOrchestrator (integration harness)', () => {
         new Error('Stellar unavailable'),
       );
 
-      await expect(
-        orchestrator.handleAuthentication({ authId: 'auth-abc' }),
-      ).rejects.toThrow('Authentication failed: Stellar unavailable');
+      let caught: unknown;
+      try {
+        await orchestrator.handleAuthentication({ authId: 'auth-abc' });
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(ServiceUnavailableException);
+      expect((caught as ServiceUnavailableException).message).toBe(
+        EXTERNAL_AUTH_FAILURE_MESSAGE,
+      );
+      expect((caught as ServiceUnavailableException).message).not.toContain(
+        'Stellar unavailable',
+      );
     });
   });
 

--- a/src/auth/auth-orchestrator.service.ts
+++ b/src/auth/auth-orchestrator.service.ts
@@ -4,6 +4,7 @@ import {
   ForbiddenException,
   BadRequestException,
   HttpException,
+  ServiceUnavailableException,
 } from '@nestjs/common';
 import {
   IdempotentUserService,
@@ -21,6 +22,16 @@ import { WalletNetwork } from '../wallets/domain/wallet.model';
 import { IdempotencyService } from '../common/idempotency/idempotency.service';
 import { AuthMetricsService } from './auth-metrics.service';
 import { RequestContextService } from '../common/request-context/request-context.service';
+
+/**
+ * Single consolidated message returned to external callers for any
+ * unclassified authentication failure (downstream DB/Stellar/wallet errors,
+ * etc). Never interpolates the underlying error — those details are logged
+ * server-side only, so partner-facing responses stay consistent and never
+ * leak internal infrastructure state.
+ */
+export const EXTERNAL_AUTH_FAILURE_MESSAGE =
+  'Authentication failed. Please try again later.';
 
 export interface AuthenticationRequest {
   authId: string;
@@ -327,7 +338,10 @@ export class AuthOrchestrator {
       // Only record 'failure_unknown' if not already classified above
       const latency = Date.now() - startTime;
       this.authMetrics.recordAttempt('failure_unknown', latency);
-      throw new Error(`Authentication failed: ${error.message}`);
+      // Consolidated, generic message — the real cause (DB/Stellar/etc) was
+      // already logged above via this.logger.error(); never forward
+      // downstream error text to external callers.
+      throw new ServiceUnavailableException(EXTERNAL_AUTH_FAILURE_MESSAGE);
     }
   }
 

--- a/src/balance-indexer/dto/balance-filter.dto.ts
+++ b/src/balance-indexer/dto/balance-filter.dto.ts
@@ -1,6 +1,7 @@
 import { IsEnum, IsOptional, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { AssetType } from '../domain/balance.model';
+import { IsStellarPublicKey } from '../../common/stellar/is-stellar-public-key.validator';
 
 export class BalanceFilterDto {
   @ApiProperty({
@@ -27,7 +28,7 @@ export class BalanceFilterDto {
     description: 'Filter by asset issuer',
     required: false,
   })
-  @IsString({ message: 'assetIssuer must be a string' })
   @IsOptional()
+  @IsStellarPublicKey()
   assetIssuer?: string;
 }

--- a/src/balance-indexer/dto/reconcile-balance.dto.ts
+++ b/src/balance-indexer/dto/reconcile-balance.dto.ts
@@ -1,6 +1,7 @@
 import { IsEnum, IsOptional, IsString, IsNotEmpty } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { AssetType } from '../domain/balance.model';
+import { IsStellarPublicKey } from '../../common/stellar/is-stellar-public-key.validator';
 
 export class ReconcileBalanceDto {
   @ApiProperty({
@@ -26,7 +27,7 @@ export class ReconcileBalanceDto {
     description: 'Asset issuer account ID (required if assetType is CREDIT_ALPHANUM4 or CREDIT_ALPHANUM12)',
     required: false,
   })
-  @IsString({ message: 'assetIssuer must be a string' })
   @IsOptional()
+  @IsStellarPublicKey()
   assetIssuer?: string;
 }

--- a/src/common/stellar/is-stellar-public-key.validator.spec.ts
+++ b/src/common/stellar/is-stellar-public-key.validator.spec.ts
@@ -1,0 +1,63 @@
+import { validate } from 'class-validator';
+import { IsStellarPublicKey } from './is-stellar-public-key.validator';
+
+class Fixture {
+  @IsStellarPublicKey()
+  publicKey: string;
+}
+
+const VALID_KEY =
+  'GBUQWP3BOUZX34ZONKXRBTLNNDOWR5HLCVPL2B4XNCLJTLMUMLTSOGBM';
+
+describe('IsStellarPublicKey', () => {
+  it('passes for a valid Stellar public key (checksum-correct)', async () => {
+    const fixture = new Fixture();
+    fixture.publicKey = VALID_KEY;
+
+    const errors = await validate(fixture);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('fails for a checksum-corrupted key that still matches the shape regex', async () => {
+    const fixture = new Fixture();
+    // Flip the last character — same length/prefix, invalid checksum.
+    fixture.publicKey = VALID_KEY.slice(0, -1) + (VALID_KEY.endsWith('A') ? 'B' : 'A');
+
+    const errors = await validate(fixture);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toEqual(
+      expect.objectContaining({
+        isStellarPublicKey: expect.stringContaining('publicKey'),
+      }),
+    );
+  });
+
+  it('fails for a secret seed (S...) passed where a public key is expected', async () => {
+    const fixture = new Fixture();
+    fixture.publicKey = 'SBUQWP3BOUZX34ZONKXRBTLNNDOWR5HLCVPL2B4XNCLJTLMUMLTSOGBM';
+
+    const errors = await validate(fixture);
+
+    expect(errors).toHaveLength(1);
+  });
+
+  it('fails for non-string input', async () => {
+    const fixture = new Fixture();
+    (fixture as unknown as { publicKey: unknown }).publicKey = 12345;
+
+    const errors = await validate(fixture);
+
+    expect(errors).toHaveLength(1);
+  });
+
+  it('fails for an empty string', async () => {
+    const fixture = new Fixture();
+    fixture.publicKey = '';
+
+    const errors = await validate(fixture);
+
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/src/common/stellar/is-stellar-public-key.validator.ts
+++ b/src/common/stellar/is-stellar-public-key.validator.ts
@@ -1,0 +1,33 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidationArguments,
+} from 'class-validator';
+import { StrKeyHelper } from '../../key-management/utils';
+
+/**
+ * Validates that a property is a well-formed Stellar Ed25519 public key
+ * (StrKey "G..." address), using stellar-sdk's checksum validation rather
+ * than a bare regex — catches typos/bit-flips that a shape-only check would miss.
+ */
+export function IsStellarPublicKey(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isStellarPublicKey',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown, _args: ValidationArguments) {
+          return (
+            typeof value === 'string' &&
+            StrKeyHelper.isValidEd25519PublicKey(value)
+          );
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must be a valid Stellar public key (StrKey "G..." address)`;
+        },
+      },
+    });
+  };
+}

--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -1,0 +1,104 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { HealthController } from './health.controller';
+
+function makeController(overrides: {
+  checkImpl?: jest.Mock;
+  gitSha?: string;
+}) {
+  const mockHealthCheckService = {
+    check:
+      overrides.checkImpl ??
+      jest.fn().mockResolvedValue({
+        status: 'ok',
+        info: { database: { status: 'up' } },
+        error: {},
+        details: { database: { status: 'up' } },
+      }),
+  };
+  const mockPrismaIndicator = { pingCheck: jest.fn() };
+  const mockPrisma = {};
+  const mockConfigService = {
+    get: jest.fn().mockImplementation((key: string, defaultValue: string) => {
+      if (key === 'GIT_SHA') return overrides.gitSha ?? defaultValue;
+      return defaultValue;
+    }),
+  };
+
+  const controller = new HealthController(
+    mockHealthCheckService as any,
+    mockPrismaIndicator as any,
+    mockPrisma as any,
+    mockConfigService as any,
+  );
+
+  return { controller, mockHealthCheckService, mockConfigService };
+}
+
+describe('HealthController', () => {
+  describe('check – success path', () => {
+    it('returns the health result with build.gitSha included', async () => {
+      const { controller } = makeController({ gitSha: 'abc1234' });
+
+      const result = await controller.check();
+
+      expect(result).toEqual({
+        status: 'ok',
+        info: { database: { status: 'up' } },
+        error: {},
+        details: { database: { status: 'up' } },
+        build: { gitSha: 'abc1234' },
+      });
+    });
+
+    it('defaults gitSha to "unknown" when GIT_SHA is not set', async () => {
+      const { controller } = makeController({});
+
+      const result = await controller.check();
+
+      expect((result as any).build).toEqual({ gitSha: 'unknown' });
+    });
+  });
+
+  describe('check – failure path', () => {
+    it('re-throws 503 with build.gitSha merged into the error body when the DB is down', async () => {
+      const dbError = new ServiceUnavailableException({
+        status: 'error',
+        info: {},
+        error: { database: { status: 'down', message: 'connection refused' } },
+        details: {
+          database: { status: 'down', message: 'connection refused' },
+        },
+      });
+
+      const { controller } = makeController({
+        checkImpl: jest.fn().mockRejectedValue(dbError),
+        gitSha: 'deadbeef',
+      });
+
+      await expect(controller.check()).rejects.toBeInstanceOf(
+        ServiceUnavailableException,
+      );
+
+      try {
+        await controller.check();
+        throw new Error('expected controller.check() to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ServiceUnavailableException);
+        const response = (err as ServiceUnavailableException).getResponse() as any;
+        expect(response.build).toEqual({ gitSha: 'deadbeef' });
+        expect(response.error.database.status).toBe('down');
+        // No secrets, only a commit hash, ever end up in the response.
+        expect(JSON.stringify(response)).not.toMatch(/secret|private[_-]?key/i);
+      }
+    });
+
+    it('re-throws non-ServiceUnavailableException errors unchanged', async () => {
+      const otherError = new Error('unexpected failure');
+      const { controller } = makeController({
+        checkImpl: jest.fn().mockRejectedValue(otherError),
+      });
+
+      await expect(controller.check()).rejects.toThrow('unexpected failure');
+    });
+  });
+});

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,26 +1,83 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, ServiceUnavailableException } from '@nestjs/common';
 import {
   HealthCheck,
   HealthCheckService,
   PrismaHealthIndicator,
 } from '@nestjs/terminus';
+import { ConfigService } from '@nestjs/config';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { PrismaService } from '../prisma/prisma.service';
 import { Public } from '../auth/public.decorator';
 
+@ApiTags('health')
 @Controller('health')
 export class HealthController {
   constructor(
     private readonly health: HealthCheckService,
     private readonly prismaIndicator: PrismaHealthIndicator,
     private readonly prisma: PrismaService,
+    private readonly configService: ConfigService,
   ) {}
 
   @Public()
   @Get()
   @HealthCheck()
-  check() {
-    return this.health.check([
-      () => this.prismaIndicator.pingCheck('database', this.prisma),
-    ]);
+  @ApiOperation({
+    summary: 'Health check, including build identity (git SHA)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Service is healthy',
+    schema: {
+      example: {
+        status: 'ok',
+        info: { database: { status: 'up' } },
+        error: {},
+        details: { database: { status: 'up' } },
+        build: { gitSha: 'a1b2c3d4e5f6' },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 503,
+    description: 'Service is unhealthy (e.g. database unreachable)',
+    schema: {
+      example: {
+        status: 'error',
+        info: {},
+        error: { database: { status: 'down', message: 'connection refused' } },
+        details: { database: { status: 'down', message: 'connection refused' } },
+        build: { gitSha: 'a1b2c3d4e5f6' },
+      },
+    },
+  })
+  async check() {
+    const build = { gitSha: this.getGitSha() };
+
+    try {
+      const result = await this.health.check([
+        () => this.prismaIndicator.pingCheck('database', this.prisma),
+      ]);
+      return { ...result, build };
+    } catch (err) {
+      if (err instanceof ServiceUnavailableException) {
+        const response = err.getResponse();
+        const body =
+          typeof response === 'object' && response !== null
+            ? response
+            : { message: response };
+        throw new ServiceUnavailableException({ ...body, build });
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Git SHA of the running build, injected at container build time via the
+   * GIT_SHA env var (see Dockerfile). Never sourced from anything that could
+   * leak secrets — just a commit hash.
+   */
+  private getGitSha(): string {
+    return this.configService.get<string>('GIT_SHA', 'unknown');
   }
 }

--- a/src/transactions/dto/build-transaction.dto.ts
+++ b/src/transactions/dto/build-transaction.dto.ts
@@ -1,24 +1,68 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsIn,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+  ValidateIf,
+} from 'class-validator';
+import { IsStellarPublicKey } from '../../common/stellar/is-stellar-public-key.validator';
+
+/** Positive decimal amount — must be > 0, e.g. "10", "0.0000001" */
+const AMOUNT_REGEX = /^(?!0(\.0+)?$)\d+(\.\d{1,7})?$/;
+
 export class BuildTransactionDto {
   /** Stellar public key of the source account */
+  @ApiProperty({
+    example: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEF',
+    description: 'Stellar public key of the source account',
+  })
+  @IsStellarPublicKey()
   sourcePublicKey: string;
 
   /** Stellar public key of the destination account */
+  @ApiProperty({
+    example: 'GDEF1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEF',
+    description: 'Stellar public key of the destination account',
+  })
+  @IsStellarPublicKey()
   destinationPublicKey: string;
 
   /** Amount to send (string for precision, e.g. "10.5000000") */
+  @ApiProperty({ example: '10.5000000' })
+  @IsString()
+  @Matches(AMOUNT_REGEX, {
+    message: 'amount must be a positive decimal with up to 7 decimal places',
+  })
   amount: string;
 
   /**
    * Asset to send.
    * Use "native" for XLM, or provide code + issuer for a custom asset.
    */
+  @ApiProperty({ example: 'native', description: '"native" for XLM, or an asset code' })
+  @IsString()
+  @IsNotEmpty()
   assetCode: string; // "native" | "USDC" | etc.
-  assetIssuer?: string; // Required when assetCode !== "native"
+
+  /** Required when assetCode !== "native" */
+  @ApiProperty({ required: false, description: 'Required when assetCode is not "native"' })
+  @ValidateIf((o) => o.assetCode !== 'native')
+  @IsStellarPublicKey()
+  assetIssuer?: string;
 
   /** Optional memo text (max 28 bytes) */
+  @ApiProperty({ required: false, example: 'Payment for services' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(28)
   memo?: string;
 
   /** Network: "TESTNET" | "MAINNET" */
+  @ApiProperty({ enum: ['TESTNET', 'MAINNET'], example: 'TESTNET' })
+  @IsIn(['TESTNET', 'MAINNET'])
   network: 'TESTNET' | 'MAINNET';
 }
 

--- a/src/transactions/dto/create-transaction.dto.ts
+++ b/src/transactions/dto/create-transaction.dto.ts
@@ -1,4 +1,5 @@
 import { MemoType } from '../../common/stellar/memo.util';
+import { IsStellarPublicKey } from '../../common/stellar/is-stellar-public-key.validator';
 import {
   IsEnum,
   IsNotEmpty,
@@ -17,9 +18,6 @@ import { AssetType } from '../../balance-indexer/domain/balance.model';
 /** Positive decimal amount — must be > 0, e.g. "10", "0.0000001", "922337203685.4775807" */
 const AMOUNT_REGEX = /^(?!0(\.0+)?$)\d+(\.\d{1,7})?$/;
 
-/** Stellar public key: G followed by 55 uppercase alphanumeric chars */
-const STELLAR_PUBLIC_KEY_REGEX = /^G[A-Z0-9]{55}$/;
-
 export class TransactionAssetDto {
   @IsEnum(AssetType)
   type: AssetType;
@@ -33,10 +31,7 @@ export class TransactionAssetDto {
 
   /** Required for non-native assets */
   @ValidateIf((o) => o.type !== AssetType.NATIVE)
-  @IsString()
-  @Matches(STELLAR_PUBLIC_KEY_REGEX, {
-    message: 'issuer must be a valid Stellar public key',
-  })
+  @IsStellarPublicKey()
   issuer?: string;
 }
 

--- a/src/transactions/dto/fee-bump-transaction.dto.ts
+++ b/src/transactions/dto/fee-bump-transaction.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, IsIn } from 'class-validator';
+import { IsStellarPublicKey } from '../../common/stellar/is-stellar-public-key.validator';
 
 /**
  * Request body for the fee-bump submission endpoint.
@@ -34,8 +35,7 @@ export class FeeBumpTransactionDto {
       'Stellar public key of the fee-source (sponsor) account that will pay the fee.',
     example: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEF',
   })
-  @IsString()
-  @IsNotEmpty()
+  @IsStellarPublicKey()
   feeSourcePublicKey: string;
 
   /**
@@ -72,8 +72,7 @@ export class FeeBumpTransactionDto {
     enum: ['TESTNET', 'MAINNET'],
     example: 'TESTNET',
   })
-  @IsString()
-  @IsNotEmpty()
+  @IsIn(['TESTNET', 'MAINNET'])
   network: 'TESTNET' | 'MAINNET';
 }
 

--- a/src/transactions/fee-bump.service.spec.ts
+++ b/src/transactions/fee-bump.service.spec.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, ServiceUnavailableException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ServiceUnavailableException,
+  HttpException,
+} from '@nestjs/common';
 import { FeeBumpService } from './fee-bump.service';
 import { TransactionStatus } from './domain/transaction.model';
 
@@ -61,6 +65,7 @@ function makeService(overrides: {
   horizonPost?: jest.Mock;
   getDecryptedPrivateKey?: jest.Mock;
   updateStatus?: jest.Mock;
+  mainnetPaymentSubmitEnabled?: boolean;
 }) {
   const mockHttp = (createRequestIdAwareAxios as jest.Mock)();
   if (overrides.horizonPost) {
@@ -84,16 +89,29 @@ function makeService(overrides: {
     }),
   };
 
+  const mockFeatureFlagService = {
+    isEnabled: jest
+      .fn()
+      .mockReturnValue(overrides.mainnetPaymentSubmitEnabled ?? true),
+  };
+
   const service = new FeeBumpService(
     mockConfigService as any,
     mockWalletsService as any,
     mockTransactionsService as any,
+    mockFeatureFlagService as any,
   );
 
   // Inject the mock http directly
   (service as any).http = mockHttp;
 
-  return { service, mockHttp, mockWalletsService, mockTransactionsService };
+  return {
+    service,
+    mockHttp,
+    mockWalletsService,
+    mockTransactionsService,
+    mockFeatureFlagService,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -159,6 +177,63 @@ describe('FeeBumpService', () => {
       await service.submitFeeBump({ ...VALID_DTO, transactionId: undefined });
 
       expect(mockTransactionsService.updateStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Mainnet feature flag
+  // -------------------------------------------------------------------------
+  describe('submitFeeBump – mainnet_payment_submit feature flag', () => {
+    it('rejects MAINNET submission with 403 when the flag is disabled', async () => {
+      const mockPost = jest.fn();
+      const { service, mockFeatureFlagService } = makeService({
+        horizonPost: mockPost,
+        mainnetPaymentSubmitEnabled: false,
+      });
+
+      await expect(
+        service.submitFeeBump({ ...VALID_DTO, network: 'MAINNET' }),
+      ).rejects.toThrow(HttpException);
+
+      expect(mockFeatureFlagService.isEnabled).toHaveBeenCalledWith(
+        'mainnet_payment_submit',
+      );
+      // Never reaches Horizon once the flag denies the request.
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('allows MAINNET submission when the flag is enabled', async () => {
+      const mockPost = jest.fn().mockResolvedValue({
+        data: { hash: 'mainnet-hash', successful: true },
+        status: 200,
+      });
+      const { service } = makeService({
+        horizonPost: mockPost,
+        mainnetPaymentSubmitEnabled: true,
+      });
+
+      const result = await service.submitFeeBump({
+        ...VALID_DTO,
+        network: 'MAINNET',
+      });
+
+      expect(result.stellarHash).toBe('mainnet-hash');
+      expect(mockPost).toHaveBeenCalled();
+    });
+
+    it('does not consult the flag for TESTNET submissions', async () => {
+      const mockPost = jest.fn().mockResolvedValue({
+        data: { hash: 'testnet-hash', successful: true },
+        status: 200,
+      });
+      const { service, mockFeatureFlagService } = makeService({
+        horizonPost: mockPost,
+        mainnetPaymentSubmitEnabled: false,
+      });
+
+      await service.submitFeeBump({ ...VALID_DTO, network: 'TESTNET' });
+
+      expect(mockFeatureFlagService.isEnabled).not.toHaveBeenCalled();
     });
   });
 

--- a/src/transactions/fee-bump.service.ts
+++ b/src/transactions/fee-bump.service.ts
@@ -4,8 +4,11 @@ import {
   BadRequestException,
   ServiceUnavailableException,
   NotFoundException,
+  HttpException,
+  HttpStatus,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { FeatureFlagService } from '../common/feature-flags/feature-flag.service';
 import {
   TransactionBuilder,
   Transaction,
@@ -48,6 +51,7 @@ export class FeeBumpService {
     private readonly configService: ConfigService,
     private readonly walletsService: WalletsService,
     private readonly transactionsService: TransactionsService,
+    private readonly featureFlagService: FeatureFlagService,
   ) {
     const testnetUrl = this.configService.get<string>(
       'STELLAR_HORIZON_URL',
@@ -75,6 +79,24 @@ export class FeeBumpService {
       transactionId,
       network,
     } = dto;
+
+    // --- 0. Mainnet kill-switch ------------------------------------------------
+    if (
+      network === 'MAINNET' &&
+      !this.featureFlagService.isEnabled('mainnet_payment_submit')
+    ) {
+      this.logger.warn(
+        'Rejected fee-bump submission: mainnet_payment_submit flag is disabled',
+      );
+      throw new HttpException(
+        {
+          statusCode: HttpStatus.FORBIDDEN,
+          message:
+            'Mainnet payment submission is not available at this time. (Flag: mainnet_payment_submit)',
+        },
+        HttpStatus.FORBIDDEN,
+      );
+    }
 
     // --- 1. Decode inner transaction -----------------------------------------
     let innerTx: Transaction;

--- a/src/transactions/transactions.controller.ts
+++ b/src/transactions/transactions.controller.ts
@@ -152,6 +152,11 @@ export class TransactionsController {
     },
   })
   @ApiResponse({ status: 400, description: 'Invalid XDR or Horizon rejection' })
+  @ApiResponse({
+    status: 403,
+    description:
+      'Mainnet payment submission is disabled (mainnet_payment_submit feature flag is off)',
+  })
   @ApiResponse({ status: 503, description: 'Horizon unavailable' })
   @Post('fee-bump')
   @SensitiveEndpoint()


### PR DESCRIPTION
## Title
Add Stellar address validation, mainnet payment kill-switch, build SHA in health check, and consolidated auth error messages

## Summary

- **Validate Stellar addresses in DTOs** — added a checksum-based `@IsStellarPublicKey()` validator (backed by `StrKeyHelper`/stellar-sdk, not just a shape regex) and wired it into every DTO that accepts a Stellar address: `BuildTransactionDto`, `FeeBumpTransactionDto`, `CreateTransactionDto`, `ReconcileBalanceDto`, `BalanceFilterDto`. `BuildTransactionDto` previously had **no** validation decorators at all.
- **Mainnet payment submit feature flag** — `FeeBumpService.submitFeeBump` now checks a `mainnet_payment_submit` flag (`FEATURE_MAINNET_PAYMENT_SUBMIT`) before submitting any `network: "MAINNET"` fee-bump transaction to Horizon, returning a `403` if disabled. `TESTNET` submissions are unaffected.
- **Build git SHA in health endpoint** — `GET /health` now returns `build: { gitSha }`, sourced from a `GIT_SHA` env var (wired into the `Dockerfile` as a build arg), merged into both the healthy response and the `503` failure body for a consistent shape.
- **Consolidated external auth error messages** — `POST /auth/authenticate` no longer leaks raw downstream error text (e.g. `"DB unavailable"`, `"Stellar unavailable"`) into the HTTP response. Unclassified failures now throw a single `ServiceUnavailableException` with a generic, consolidated message; the real cause is still logged server-side only.

## Details

### #515 — Validate Stellar addresses in DTOs
- New reusable decorator: `src/common/stellar/is-stellar-public-key.validator.ts` (+ spec)
- Applied to `build-transaction.dto.ts`, `fee-bump-transaction.dto.ts`, `create-transaction.dto.ts`, `reconcile-balance.dto.ts`, `balance-filter.dto.ts`
- Replaced a shape-only regex (`^G[A-Z0-9]{55}$`) with real StrKey checksum validation, catching typos/bit-flips a regex would miss

### #522 — Add feature flag for mainnet payment submit
- `FeeBumpService` now injects `FeatureFlagService`; gates MAINNET submissions before any wallet key decryption or Horizon call
- Swagger docs updated with the new `403` response
- `docs/MAINNET-PAYMENT-FEATURE-FLAG.md` added
- Tests: flag disabled → 403 (Horizon never called), flag enabled → succeeds, TESTNET never consults the flag

### #548 — Expose build git sha in health endpoint
- `HealthController` reads `GIT_SHA` via `ConfigService` (default `"unknown"`), merges `build.gitSha` into success and 503 failure responses
- `Dockerfile` — `ARG GIT_SHA=unknown` / `ENV GIT_SHA=$GIT_SHA`, injectable via `--build-arg GIT_SHA=$(git rev-parse HEAD)`
- `.env.example` documents the new var
- New `health.controller.spec.ts` covering success, missing-env default, DB-down 503 (with gitSha still present), and non-Terminus errors passing through unchanged

### #550 — Consolidate external auth error messages
- `auth-orchestrator.service.ts`: replaced `throw new Error(\`Authentication failed: ${error.message}\`)` (a plain `Error`, only sanitized in `NODE_ENV=production`) with `throw new ServiceUnavailableException(EXTERNAL_AUTH_FAILURE_MESSAGE)` — a single consolidated, generic message, consistent with the filter's `HttpException` handling used everywhere else
- Real error cause is still logged via the existing `logger.error(...)` call — never dropped, just never echoed to the caller
- Updated `auth-orchestrator.integration.spec.ts` and `auth-metrics.integration.spec.ts`, which previously asserted on the leaked raw error text as expected behavior, to instead assert the generic message and that the raw cause is absent

## Test plan
- [ ] `npm ci && npm test` — not run in this environment (no `node_modules` present in the sandbox); please run before merging
- [x] Reviewed diffs for each change manually
- [ ] Manual smoke test of `POST /transactions/build`, `POST /transactions/fee-bump` (MAINNET on/off), `GET /health`, `POST /auth/authenticate` failure path

Closes #515
Closes #522
Closes #548
Closes #550
